### PR TITLE
#914: Implements group search

### DIFF
--- a/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -49,11 +49,6 @@ object SearchApiProperties extends LazyLogging {
     "learningpaths" -> "learningpath"
   )
 
-  val taxonomySubjectMaterialName = "Fagstoff"
-  val taxonomyLearningPathName = "Læringssti"
-  val taxonomyTasksName = "Oppgaver og aktiviteter"
-  val taxonomyResourceTypeNames = List(taxonomySubjectMaterialName, taxonomyLearningPathName, taxonomyTasksName)
-
   val DefaultPageSize = 10
   val MaxPageSize = 100
   val IndexBulkSize = 2000

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -118,7 +118,8 @@ trait SearchController {
         supportedLanguages = List.empty
       )
 
-      groupSearch(query, settings.copy(resourceTypes = resourceTypes))
+      val x = groupSearch(query, settings.copy(resourceTypes = resourceTypes))
+      x
     }
 
     private def searchInGroup(query: Option[String], group: String, settings: SearchSettings): Try[GroupSearchResult] = {
@@ -142,7 +143,8 @@ trait SearchController {
     }
 
     private def groupSearch(query: Option[String], settings: SearchSettings) = {
-      implicit val ec: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newWorkStealingPool(settings.resourceTypes.size))
+      implicit val ec: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(settings.resourceTypes.size))
+
       val searches = settings.resourceTypes.map(group =>
         Future{searchInGroup(query, group, settings.copy(resourceTypes = List(group)))})
 

--- a/src/main/scala/no/ndla/searchapi/integration/Elastic4sClient.scala
+++ b/src/main/scala/no/ndla/searchapi/integration/Elastic4sClient.scala
@@ -7,8 +7,6 @@
 
 package no.ndla.searchapi.integration
 
-import javax.naming.directory.InitialDirContext
-
 import com.amazonaws.regions.{Region, Regions}
 import com.netaporter.uri.dsl._
 import com.sksamuel.elastic4s.ElasticsearchClientUri

--- a/src/main/scala/no/ndla/searchapi/model/api/GroupSearchResult.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/GroupSearchResult.scala
@@ -1,0 +1,24 @@
+/*
+ * Part of NDLA search_api.
+ * Copyright (C) 2018 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.searchapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+import scala.annotation.meta.field
+
+@ApiModel(description = "Search result for group search")
+case class GroupSearchResult(@(ApiModelProperty@field)(description = "The total number of resources matching this query") totalCount: Long,
+                             @(ApiModelProperty@field)(description = "Type of resources in this object") resourceType: String,
+                             @(ApiModelProperty@field)(description = "For which page results are shown from") page: Int,
+                             @(ApiModelProperty@field)(description = "The number of results per page") pageSize: Int,
+                             @(ApiModelProperty@field)(description = "The chosen search language") language: String,
+                             @(ApiModelProperty@field)(description = "The search results") results: Seq[GroupSummary])
+
+@ApiModel(description = "Search result for group search")
+case class GroupSummary(@(ApiModelProperty@field)(description = "The unique id of this resource") id: Long,
+                        @(ApiModelProperty@field)(description = "The title of the resource") title: Title,
+                        @(ApiModelProperty@field)(description = "The url pointing to the resource") url: String)

--- a/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
@@ -13,9 +13,6 @@ import scala.annotation.meta.field
 
 @ApiModel(description = "Information about search-results")
 case class MultiSearchResult(@(ApiModelProperty@field)(description = "The total number of resources matching this query") totalCount: Long,
-                             @(ApiModelProperty@field)(description = "Number of total matched learningpaths") totalCountLearningPaths: Long,
-                             @(ApiModelProperty@field)(description = "Number of total matched 'fagstoff'") totalCountSubjectMaterial: Long,
-                             @(ApiModelProperty@field)(description = "Number of total matched 'oppgaver'") totalCountTasks: Long,
                              @(ApiModelProperty@field)(description = "For which page results are shown from") page: Int,
                              @(ApiModelProperty@field)(description = "The number of results per page") pageSize: Int,
                              @(ApiModelProperty@field)(description = "The chosen search language") language: String,

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContext.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContext.scala
@@ -7,16 +7,17 @@
 
 package no.ndla.searchapi.model.search
 
-import no.ndla.searchapi.model.taxonomy.{ContextFilter, SearchableContextFilters}
+import no.ndla.searchapi.model.taxonomy.{SearchableContextFilters, TaxonomyFilter}
 import org.json4s.{CustomSerializer, DefaultFormats, Extraction}
-import org.json4s.JsonAST.{JArray, JField, JObject}
+import org.json4s.JsonAST.{JArray, JField, JObject, JString}
 
 case class SearchableTaxonomyContext(id: String,
+                                     subjectId: String,
                                      subject: SearchableLanguageValues,
                                      path: String,
                                      breadcrumbs: SearchableLanguageList,
                                      contextType: String,
-                                     filters: List[ContextFilter],
+                                     filters: List[TaxonomyFilter],
                                      resourceTypes: SearchableLanguageList)
 
 class SearchableTaxonomyContextSerializer
@@ -27,6 +28,7 @@ class SearchableTaxonomyContextSerializer
 
           SearchableTaxonomyContext(
             id = (obj \ "id").extract[String],
+            subjectId = (obj \ "subjectId").extract[String],
             subject = SearchableLanguageValues("subject", obj),
             path = (obj \ "path").extract[String],
             breadcrumbs = SearchableLanguageList("breadcrumbs", obj),
@@ -46,6 +48,7 @@ class SearchableTaxonomyContextSerializer
 
           val filters = JArray(context.filters.map(f => {
             val fields: List[JField] =
+              JField("filterId", JString(f.filterId)) +:
               List(f.name.toJsonField("name"),
                    f.relevance.toJsonField("relevance")).flatten
 
@@ -67,14 +70,17 @@ object LanguagelessSearchableTaxonomyContext {
 
   case class LanguagelessSearchableTaxonomyContext(id: String,
                                                    path: String,
-                                                   contextType: String)
+                                                   subjectId: String,
+                                                   contextType: String
+                                                  )
 
   def apply(searchableTaxonomyContext: SearchableTaxonomyContext)
     : LanguagelessSearchableTaxonomyContext = {
     LanguagelessSearchableTaxonomyContext(
-      searchableTaxonomyContext.id,
-      searchableTaxonomyContext.path,
-      searchableTaxonomyContext.contextType
+      id = searchableTaxonomyContext.id,
+      path = searchableTaxonomyContext.path,
+      subjectId = searchableTaxonomyContext.subjectId,
+      contextType = searchableTaxonomyContext.contextType
     )
   }
 }

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContext.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContext.scala
@@ -18,7 +18,9 @@ case class SearchableTaxonomyContext(id: String,
                                      breadcrumbs: SearchableLanguageList,
                                      contextType: String,
                                      filters: List[TaxonomyFilter],
-                                     resourceTypes: SearchableLanguageList)
+                                     resourceTypes: SearchableLanguageList,
+                                     resourceTypeIds: List[String]
+                                    )
 
 class SearchableTaxonomyContextSerializer
     extends CustomSerializer[SearchableTaxonomyContext](_ =>
@@ -34,7 +36,8 @@ class SearchableTaxonomyContextSerializer
             breadcrumbs = SearchableLanguageList("breadcrumbs", obj),
             contextType = (obj \ "contextType").extract[String],
             filters = SearchableContextFilters("filters", obj),
-            resourceTypes = SearchableLanguageList("resourceTypes", obj)
+            resourceTypes = SearchableLanguageList("resourceTypes", obj),
+            resourceTypeIds = (obj \ "resourceTypeIds").extract[List[String]]
           )
       }, {
         case context: SearchableTaxonomyContext =>
@@ -71,8 +74,8 @@ object LanguagelessSearchableTaxonomyContext {
   case class LanguagelessSearchableTaxonomyContext(id: String,
                                                    path: String,
                                                    subjectId: String,
-                                                   contextType: String
-                                                  )
+                                                   contextType: String,
+                                                   resourceTypeIds: List[String])
 
   def apply(searchableTaxonomyContext: SearchableTaxonomyContext)
     : LanguagelessSearchableTaxonomyContext = {
@@ -80,7 +83,8 @@ object LanguagelessSearchableTaxonomyContext {
       id = searchableTaxonomyContext.id,
       path = searchableTaxonomyContext.path,
       subjectId = searchableTaxonomyContext.subjectId,
-      contextType = searchableTaxonomyContext.contextType
+      contextType = searchableTaxonomyContext.contextType,
+      resourceTypeIds = searchableTaxonomyContext.resourceTypeIds
     )
   }
 }

--- a/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyFilter.scala
+++ b/src/main/scala/no/ndla/searchapi/model/taxonomy/TaxonomyFilter.scala
@@ -11,18 +11,19 @@ import no.ndla.searchapi.model.search.SearchableLanguageValues
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST.{JObject, JString}
 
-case class ContextFilter(name: SearchableLanguageValues, relevance: SearchableLanguageValues)
+case class TaxonomyFilter(filterId: String, name: SearchableLanguageValues, relevance: SearchableLanguageValues)
 
 object SearchableContextFilters {
-  def apply(name: String, jsonObject: JObject): List[ContextFilter] = {
+  def apply(name: String, jsonObject: JObject): List[TaxonomyFilter] = {
     implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
 
     val filters = (jsonObject \ "filters").extract[List[JObject]]
 
     filters.map(filter => {
+      val id = (filter \ "filterId").extract[String]
       val names = SearchableLanguageValues("name", filter)
       val relevances = SearchableLanguageValues("relevance", filter)
-      ContextFilter(names, relevances)
+      TaxonomyFilter(id, names, relevances)
     })
   }
 }

--- a/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -54,20 +54,7 @@ trait ArticleIndexService {
           keywordField("articleType"),
           longField("metaImageId"),
           keywordField("supportedLanguages"),
-          nestedField("contexts").fields(
-            List(
-              keywordField("id"),
-              keywordField("path"),
-              keywordField("contextType")
-            ) ++
-            generateLanguageSupportedFieldList("resourceTypes", keepRaw = true) ++
-            generateLanguageSupportedFieldList("subject", keepRaw = true) ++
-            generateLanguageSupportedFieldList("breadcrumbs") ++
-            List(nestedField("filters").fields(
-                generateLanguageSupportedFieldList("name", keepRaw = true) ++
-                generateLanguageSupportedFieldList("relevance")
-            ))
-          )
+          getTaxonomyContextMapping
         )
           ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++

--- a/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -328,7 +328,8 @@ trait IndexService {
           keywordField("id"),
           keywordField("path"),
           keywordField("contextType"),
-          keywordField("subjectId")
+          keywordField("subjectId"),
+          keywordField("resourceTypeIds")
         ) ++
           generateLanguageSupportedFieldList("resourceTypes", keepRaw = true) ++
           generateLanguageSupportedFieldList("subject", keepRaw = true) ++

--- a/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -15,7 +15,7 @@ import com.sksamuel.elastic4s.alias.AliasActionDefinition
 import com.typesafe.scalalogging.LazyLogging
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.indexes.IndexDefinition
-import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition}
+import com.sksamuel.elastic4s.mappings.{FieldDefinition, MappingDefinition, NestedFieldDefinition}
 import no.ndla.network.AuthUser
 import no.ndla.searchapi.SearchApiProperties
 import no.ndla.searchapi.integration._
@@ -319,6 +319,27 @@ trait IndexService {
       languageAnalyzers.map(langAnalyzer =>
         nestedField(s"$fieldName.${langAnalyzer.lang}")
           .fields(subFields.map(f => f.analyzer(langAnalyzer.analyzer)))
+      )
+    }
+
+    protected def getTaxonomyContextMapping: NestedFieldDefinition = {
+      nestedField("contexts").fields(
+        List(
+          keywordField("id"),
+          keywordField("path"),
+          keywordField("contextType"),
+          keywordField("subjectId")
+        ) ++
+          generateLanguageSupportedFieldList("resourceTypes", keepRaw = true) ++
+          generateLanguageSupportedFieldList("subject", keepRaw = true) ++
+          generateLanguageSupportedFieldList("breadcrumbs") ++
+          List(
+            nestedField("filters").fields(
+            List(keywordField("filterId")) ++
+              generateLanguageSupportedFieldList("name", keepRaw = true) ++
+              generateLanguageSupportedFieldList("relevance")
+            )
+          )
       )
     }
 

--- a/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
@@ -74,20 +74,7 @@ trait LearningPathIndexService {
           ),
           intField("isBasedOn"),
           keywordField("supportedLanguages"),
-          nestedField("contexts").fields(
-            List(
-              keywordField("id"),
-              keywordField("path"),
-              keywordField("contextType")
-            ) ++
-              generateLanguageSupportedFieldList("resourceTypes", keepRaw = true) ++
-              generateLanguageSupportedFieldList("subject", keepRaw = true) ++
-              generateLanguageSupportedFieldList("breadcrumbs") ++
-              List(nestedField("filters").fields(
-                generateLanguageSupportedFieldList("name", keepRaw = true) ++
-                  generateLanguageSupportedFieldList("relevance")
-              ))
-          )
+          getTaxonomyContextMapping
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("description") ++

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -181,11 +181,9 @@ trait MultiSearchService {
     private def subjectFilter(subjects: List[String]) = {
       if (subjects.isEmpty) None else Some(
         boolQuery().must(
-          subjects.map(subjectName =>
+          subjects.map(subjectId =>
             nestedQuery("contexts").query(
-              boolQuery().should(
-                ISO639.languagePriority.map(l => termQuery(s"contexts.subject.$l.raw", subjectName))
-              )
+              termQuery(s"contexts.subjectId", subjectId)
             )
           )
         )

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -207,11 +207,9 @@ trait MultiSearchService {
     private def resourceTypeFilter(resourceTypes: List[String]) = {
       if (resourceTypes.isEmpty) None else Some(
         boolQuery().must(
-          resourceTypes.map(resourceTypeName =>
+          resourceTypes.map(resourceTypeId =>
             nestedQuery("contexts").query(
-              boolQuery().should(
-                ISO639.languagePriority.map(l => termQuery(s"contexts.resourceTypes.$l.raw", resourceTypeName))
-              )
+              termQuery(s"contexts.resourceTypeIds", resourceTypeId)
             )
           )
         )

--- a/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
+++ b/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
@@ -60,5 +60,13 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     }
   }
 
+  test("That /group/ returns 200 ok") {
+    val multiResult = api.MultiSearchResult(0, 0, 0, 0, 1, 10, "nb", Seq.empty)
+    when(multiSearchService.all(any[SearchSettings])).thenReturn(Success(multiResult))
+    get("/test/group/?resource-types=test") {
+      status should equal (200)
+    }
+  }
+
 
 }

--- a/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
+++ b/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
@@ -53,7 +53,7 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   }
 
   test("That / returns 200 ok") {
-    val multiResult = api.MultiSearchResult(0, 0, 0, 0, 1, 10, "nb", Seq.empty)
+    val multiResult = api.MultiSearchResult(0, 1, 10, "nb", Seq.empty)
     when(multiSearchService.all(any[SearchSettings])).thenReturn(Success(multiResult))
     get("/test/") {
       status should equal (200)
@@ -61,7 +61,7 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   }
 
   test("That /group/ returns 200 ok") {
-    val multiResult = api.MultiSearchResult(0, 0, 0, 0, 1, 10, "nb", Seq.empty)
+    val multiResult = api.MultiSearchResult(0, 1, 10, "nb", Seq.empty)
     when(multiSearchService.all(any[SearchSettings])).thenReturn(Success(multiResult))
     get("/test/group/?resource-types=test") {
       status should equal (200)

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -59,6 +59,7 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
           relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff")))
         )
         ),
+        resourceTypeIds = List("urn:resourcetype:subjectMaterial", "urn:resourcetype:academicArticle"),
         resourceTypes = SearchableLanguageList(Seq(LanguageValue("nb", Seq("Fagstoff", "Fagartikkel"))))
       )
     )

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -8,7 +8,7 @@
 package no.ndla.searchapi.model.search
 
 import no.ndla.searchapi.model.domain.article.LearningResourceType
-import no.ndla.searchapi.model.taxonomy.ContextFilter
+import no.ndla.searchapi.model.taxonomy.TaxonomyFilter
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 import org.json4s.native.Serialization.{read, write}
 import org.json4s.Formats
@@ -46,13 +46,15 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
     val taxonomyContexts = List(
       SearchableTaxonomyContext(
         id = "urn:resource:101",
+        subjectId = "urn:subject:1",
         subject = SearchableLanguageValues(Seq(LanguageValue("nb", "Matte"))),
         path = "/subject:3/topic:1/topic:151/resource:101",
         breadcrumbs = SearchableLanguageList(Seq(
           LanguageValue("nb", Seq("Matte", "Østen for solen", "Vesten for månen"))
         )),
         contextType = LearningResourceType.Article.toString,
-        filters = List(ContextFilter(
+        filters = List(TaxonomyFilter(
+          filterId = "urn:filter:1",
           name = SearchableLanguageValues(Seq(LanguageValue("nb", "VG1"))),
           relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff")))
         )

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
@@ -49,6 +49,7 @@ class SearchableLearningPathTest extends UnitSuite with TestEnvironment {
           relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff")))
         )
         ),
+        resourceTypeIds = List("urn:resourcetype:subjectMaterial", "urn:resourcetype:academicArticle"),
         resourceTypes = SearchableLanguageList(Seq(LanguageValue("nb", Seq("Fagstoff", "Fagartikkel"))))
       )
     )

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableLearningPathTest.scala
@@ -10,7 +10,7 @@ package no.ndla.searchapi.model.search
 import no.ndla.searchapi.model.api.learningpath.{Author, Copyright, License}
 import no.ndla.searchapi.model.domain.article.LearningResourceType
 import no.ndla.searchapi.model.domain.learningpath.{LearningPathStatus, LearningPathVerificationStatus, StepType}
-import no.ndla.searchapi.model.taxonomy.ContextFilter
+import no.ndla.searchapi.model.taxonomy.TaxonomyFilter
 import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 import org.json4s.Formats
 import org.json4s.native.Serialization.{read, write}
@@ -36,13 +36,15 @@ class SearchableLearningPathTest extends UnitSuite with TestEnvironment {
     val taxonomyContexts = List(
       SearchableTaxonomyContext(
         id = "urn:resource:101",
+        subjectId = "urn:subject:1",
         subject = SearchableLanguageValues(Seq(LanguageValue("nb", "Matte"))),
         path = "/subject:3/topic:1/topic:151/resource:101",
         breadcrumbs = SearchableLanguageList(Seq(
           LanguageValue("nb", Seq("Matte", "Østen for solen", "Vesten for månen"))
         )),
         contextType = LearningResourceType.Article.toString,
-        filters = List(ContextFilter(
+        filters = List(TaxonomyFilter(
+          filterId = "urn:filter:1",
           name = SearchableLanguageValues(Seq(LanguageValue("nb", "VG1"))),
           relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff")))
         )

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContextTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContextTest.scala
@@ -34,6 +34,7 @@ class SearchableTaxonomyContextTest extends UnitSuite with TestEnvironment {
           relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff")))
         )
         ),
+        resourceTypeIds = List("urn:resourcetype:subjectMaterial", "urn:resourcetype:academicArticle"),
         resourceTypes = SearchableLanguageList(Seq(LanguageValue("nb", Seq("Fagstoff", "Fagartikkel"))))
       )
     )

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContextTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableTaxonomyContextTest.scala
@@ -8,7 +8,7 @@
 package no.ndla.searchapi.model.search
 
 import no.ndla.searchapi.model.domain.article.LearningResourceType
-import no.ndla.searchapi.model.taxonomy.ContextFilter
+import no.ndla.searchapi.model.taxonomy.TaxonomyFilter
 import no.ndla.searchapi.{TestEnvironment, UnitSuite}
 import org.json4s.Formats
 import org.json4s.native.Serialization.{read, write}
@@ -21,13 +21,15 @@ class SearchableTaxonomyContextTest extends UnitSuite with TestEnvironment {
     val originals = List(
       SearchableTaxonomyContext(
         id = "urn:resource:101",
+        subjectId = "urn:subject:1",
         subject = SearchableLanguageValues(Seq(LanguageValue("nb", "Matte"))),
         path = "/subject:3/topic:1/topic:151/resource:101",
         breadcrumbs = SearchableLanguageList(Seq(
           LanguageValue("nb", Seq("Matte", "Østen for solen", "Vesten for månen"))
         )),
         contextType = LearningResourceType.Article.toString,
-        filters = List(ContextFilter(
+        filters = List(TaxonomyFilter(
+          filterId = "urn:filter:1",
           name = SearchableLanguageValues(Seq(LanguageValue("nb", "VG1"))),
           relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff")))
         )

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -340,11 +340,11 @@ class MultiSearchServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That filtering for subjects works as expected") {
-    val Success(search) = multiSearchService.all(searchSettings.copy(subjects = List("Historie"), language="all"))
+    val Success(search) = multiSearchService.all(searchSettings.copy(subjects = List("urn:subject:2"), language="all"))
     search.totalCount should be(6)
     search.results.map(_.id) should be(Seq(1, 5, 5, 6, 7, 11))
 
-    val Success(search2) = multiSearchService.all(searchSettings.copy(subjects = List("Historie", "Matte")))
+    val Success(search2) = multiSearchService.all(searchSettings.copy(subjects = List("urn:subject:2", "urn:subject:1")))
     search2.totalCount should be(2)
     search2.results.map(_.id) should be(Seq(1, 5))
   }

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -350,19 +350,19 @@ class MultiSearchServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That filtering for resource-types works as expected") {
-    val Success(search) = multiSearchService.all(searchSettings.copy(resourceTypes = List("Fagartikkel")))
+    val Success(search) = multiSearchService.all(searchSettings.copy(resourceTypes = List("urn:resourcetype:academicArticle")))
     search.totalCount should be(2)
     search.results.map(_.id) should be(Seq(2, 5))
 
-    val Success(search2) = multiSearchService.all(searchSettings.copy(resourceTypes = List("Fagstoff")))
+    val Success(search2) = multiSearchService.all(searchSettings.copy(resourceTypes = List("urn:resourcetype:subjectMaterial")))
     search2.totalCount should be(6)
     search2.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7))
 
-    val Success(search3) = multiSearchService.all(searchSettings.copy(resourceTypes = List("Fagstoff", "Vurderingsressurs")))
+    val Success(search3) = multiSearchService.all(searchSettings.copy(resourceTypes = List("urn:resourcetype:subjectMaterial", "urn:resourcetype:reviewResource")))
     search3.totalCount should be(1)
     search3.results.map(_.id) should be(Seq(7))
 
-    val Success(search4) = multiSearchService.all(searchSettings.copy(resourceTypes = List("Læringssti")))
+    val Success(search4) = multiSearchService.all(searchSettings.copy(resourceTypes = List("urn:resourcetype:learningpath")))
     search4.totalCount should be(4)
     search4.results.map(_.id) should be(Seq(1, 2, 3, 4))
   }

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -417,15 +417,6 @@ class MultiSearchServiceTest extends UnitSuite with TestEnvironment {
     search.results.map(_.title.language) should be(Seq("nb", "nb", "nb", "nb"))
   }
 
-  test("That count of resource types is correct") {
-    val Success(search) = multiSearchService.all(searchSettings.copy(language = "nb"))
-
-    search.totalCount should be (13)
-    search.totalCountLearningPaths should be(4)
-    search.totalCountSubjectMaterial should be(6)
-
-  }
-
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false


### PR DESCRIPTION
Also updates query-params `resource-types` and `subjects` to take ids (ex: `urn:subject:1`) rather than subject name