### PR TITLE
Uses correct field for alt and url in metaImage for multiSearch learningpaths

### DIFF
--- a/src/main/scala/no/ndla/searchapi/service/search/LearningPathSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/LearningPathSearchService.scala
@@ -142,8 +142,6 @@ trait LearningPathSearchService {
           .highlighting(highlight("*"))
           .sortBy(getSortDefinition(sort, language))
 
-        val json = e4sClient.httpClient.show(searchToExecute)
-
         e4sClient.execute(searchToExecute) match {
           case Success(response) =>
             Success(

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -479,8 +479,13 @@ trait SearchConverterService {
         api.MetaDescription("", Language.UnknownLanguage))
       val url = s"${SearchApiProperties.ExternalApiUrls("learningpath-api")}/${searchableLearningPath.id}"
       val metaImage =
-        searchableLearningPath.coverPhotoId.map(id =>
-          api.MetaImage(id, "", s"${SearchApiProperties.ExternalApiUrls("raw-image")}/$id"))
+        searchableLearningPath.coverPhotoId.map(
+          id =>
+            api.MetaImage(
+              url = s"${SearchApiProperties.ExternalApiUrls("raw-image")}/$id",
+              alt = "",
+              language = language
+          ))
 
       MultiSearchSummary(
         id = searchableLearningPath.id,


### PR DESCRIPTION
resolves https://github.com/NDLANO/Issues/issues/1182