### PR TITLE
Need to use must if several resourcetypes

### DIFF
--- a/src/main/scala/no/ndla/searchapi/service/search/TaxonomyFiltering.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/TaxonomyFiltering.scala
@@ -81,7 +81,7 @@ trait TaxonomyFiltering {
     if (resourceTypes.isEmpty) None
     else
       Some(
-        boolQuery().should(
+        boolQuery().must(
           resourceTypes.map(
             resourceTypeId =>
               nestedQuery("contexts.resourceTypes").query(

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -402,11 +402,11 @@ class MultiSearchServiceTest extends UnitSuite with TestEnvironment {
     search3.results.map(_.id) should be(Seq(1, 2, 3, 4))
   }
 
-  test("That filtering for multiple resource-types returns resources from both") {
+  test("That filtering for multiple resource-types returns only resources containing both") {
     val Success(search) = multiSearchService.matchingQuery(
       searchSettings.copy(resourceTypes = List("urn:resourcetype:subjectMaterial", "urn:resourcetype:reviewResource")))
-    search.totalCount should be(7)
-    search.results.map(_.id) should be(Seq(1, 2, 3, 5, 6, 7, 12))
+    search.totalCount should be(1)
+    search.results.map(_.id) should be(Seq(7))
   }
 
   test("That filtering on learning-resource-type works") {


### PR DESCRIPTION
Dersom det søkes på fleire ressurstyper fra ndla-frontend så forventes det at utvalget innsnevres og ikkje utvides. Derfor må vi endre søket til å ha must i stedet for should for dette filteret.