### PR TITLE
Higher timeout and multiple threads for indexing in smaller chunks

### DIFF
--- a/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -55,7 +55,7 @@ object SearchApiProperties extends LazyLogging {
 
   val DefaultPageSize = 10
   val MaxPageSize = 10000
-  val IndexBulkSize = 1000
+  val IndexBulkSize = 100
   val ElasticSearchIndexMaxResultWindow = 10000
   val ElasticSearchScrollKeepAlive = "10s"
 

--- a/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
+++ b/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
@@ -59,7 +59,7 @@ trait SearchApiClient {
         "page-size" -> pageSize
       )
 
-      get[DomainDumpResults[T]](dumpDomainPath, params, timeout = 20000) match {
+      get[DomainDumpResults[T]](dumpDomainPath, params, timeout = 120000) match {
         case Success(result) =>
           logger.info(s"Fetched chunk of ${result.results.size} $name from ${baseUrl.addParams(params)}")
           Success(result)

--- a/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -10,6 +10,7 @@ package no.ndla.searchapi.service.search
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.concurrent.Executors
 
 import com.sksamuel.elastic4s.alias.AliasAction
 import com.typesafe.scalalogging.LazyLogging
@@ -24,6 +25,8 @@ import no.ndla.searchapi.model.domain.Language.languageAnalyzers
 import no.ndla.searchapi.model.taxonomy.TaxonomyBundle
 import no.ndla.searchapi.model.grep.GrepBundle
 
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 trait IndexService {
@@ -101,17 +104,29 @@ trait IndexService {
       })
     }
 
-    def sendToElastic(indexName: String, taxonomyBundle: TaxonomyBundle, grepBundle: GrepBundle)(
-        implicit mf: Manifest[D]): Try[Int] = {
+    def sendToElastic(
+        indexName: String,
+        taxonomyBundle: TaxonomyBundle,
+        grepBundle: GrepBundle
+    )(implicit mf: Manifest[D]): Try[Int] = {
+      val numThreads = 10
+      implicit val executionContext: ExecutionContextExecutorService =
+        ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(numThreads))
+
       val stream = apiClient.getChunks[D]
-      val chunks = stream
-        .map({
-          case Success(c) =>
-            val numIndexed = indexDocuments(c, indexName, taxonomyBundle, grepBundle)
-            Success(numIndexed.getOrElse(0), c.size)
-          case Failure(ex) => Failure(ex)
+      val futures = stream
+        .map(x =>
+          Future {
+            x match {
+              case Failure(ex) => Failure(ex)
+              case Success(c) =>
+                val numIndexed = indexDocuments(c, indexName, taxonomyBundle, grepBundle)
+                Success(numIndexed.getOrElse(0), c.size)
+            }
         })
         .toList
+
+      val chunks = Await.result(Future.sequence(futures), Duration.Inf)
 
       chunks.collect { case Failure(ex) => Failure(ex) } match {
         case Nil =>


### PR DESCRIPTION
Virker som database access i de andre api'ene som tar lang tid (Noen ganger over 20 sekunder for å hente ut 1000 drafts).

Går selvfølgelig an å undersøke hvorfor spørringene tar lang tid (Har sikkert noe med at vi gjør en nested spørring for å finne bare siste revision av drafts), men vet ikke om vi gidder å bruke tid på det jeg.

Denne PR'en gjør indeksering i mindre chunks og flere tråder i tillegg til å increase timeouten.
Det gjorde at indekseringsjobben i test gikk fra 13 til 10 minutter.

Om vi ikke syns kompleksiteten er verdt det så vil også bare å øke timeouten fikse "problemet", men da vil indekseringen naturligvis ta like lang tid.
Hva tenker dere @gunnarvelle @N4G1 ?

