### PR TITLE
Must specify published to prevent error in article-api indexing

### DIFF
--- a/src/main/scala/no/ndla/searchapi/model/domain/article/Article.scala
+++ b/src/main/scala/no/ndla/searchapi/model/domain/article/Article.scala
@@ -11,24 +11,24 @@ import no.ndla.searchapi.model.domain.{Content, Tag, Title}
 import org.joda.time.DateTime
 import org.json4s.FieldSerializer
 
-case class Article(
-    id: Option[Long],
-    revision: Option[Int],
-    title: Seq[Title],
-    content: Seq[ArticleContent],
-    copyright: Copyright,
-    tags: Seq[Tag],
-    requiredLibraries: Seq[RequiredLibrary],
-    visualElement: Seq[VisualElement],
-    introduction: Seq[ArticleIntroduction],
-    metaDescription: Seq[MetaDescription],
-    metaImage: Seq[ArticleMetaImage],
-    created: DateTime,
-    updated: DateTime,
-    updatedBy: String,
-    articleType: LearningResourceType.Value,
-    grepCodes: Seq[String]
-) extends Content
+case class Article(id: Option[Long],
+                   revision: Option[Int],
+                   title: Seq[Title],
+                   content: Seq[ArticleContent],
+                   copyright: Copyright,
+                   tags: Seq[Tag],
+                   requiredLibraries: Seq[RequiredLibrary],
+                   visualElement: Seq[VisualElement],
+                   introduction: Seq[ArticleIntroduction],
+                   metaDescription: Seq[MetaDescription],
+                   metaImage: Seq[ArticleMetaImage],
+                   created: DateTime,
+                   updated: DateTime,
+                   updatedBy: String,
+                   published: DateTime,
+                   articleType: LearningResourceType.Value,
+                   grepCodes: Seq[String])
+    extends Content
 
 object LearningResourceType extends Enumeration {
   val Article = Value("standard")

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -150,6 +150,7 @@ object TestData {
     today.minusDays(4),
     today.minusDays(2),
     "ndalId54321",
+    today.minusDays(2),
     LearningResourceType.Article,
     Seq.empty
   )
@@ -169,6 +170,7 @@ object TestData {
     today,
     today,
     "ndalId54321",
+    today,
     LearningResourceType.Article,
     Seq.empty
   )
@@ -188,170 +190,187 @@ object TestData {
     today,
     today,
     "ndalId54321",
+    today,
     LearningResourceType.Article,
     Seq.empty
   )
-  val sampleArticleWithByNcSa: Article = sampleArticleWithPublicDomain.copy(copyright = byNcSaCopyright)
-  val sampleArticleWithCopyrighted: Article = sampleArticleWithPublicDomain.copy(copyright = copyrighted)
+
+  val sampleArticleWithByNcSa: Article =
+    sampleArticleWithPublicDomain.copy(copyright = byNcSaCopyright, published = DateTime.now())
+
+  val sampleArticleWithCopyrighted: Article =
+    sampleArticleWithPublicDomain.copy(copyright = copyrighted, published = DateTime.now())
 
   val article1: Article = TestData.sampleArticleWithByNcSa.copy(
     id = Option(1),
     title = List(Title("Batmen er på vift med en bil", "nb")),
-    introduction = List(ArticleIntroduction("Batmen", "nb")),
-    metaDescription = List.empty,
     content = List(
       ArticleContent("Bilde av en <strong>bil</strong> flaggermusmann som vifter med vingene <em>bil</em>.", "nb")),
-    visualElement = List.empty,
+    copyright = byNcSaCopyright.copy(creators = List(Author("Forfatter", "Kjekspolitiet"))),
     tags = List(Tag(List("fugl"), "nb")),
+    visualElement = List.empty,
+    introduction = List(ArticleIntroduction("Batmen", "nb")),
+    metaDescription = List.empty,
     created = today.minusDays(4),
     updated = today.minusDays(3),
-    copyright = byNcSaCopyright.copy(creators = List(Author("Forfatter", "Kjekspolitiet"))),
+    published = today.minusDays(3),
     grepCodes = Seq("K123", "K456")
   )
 
   val article2: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(2),
     title = List(Title("Pingvinen er ute og går", "nb")),
-    introduction = List(ArticleIntroduction("Pingvinen", "nb")),
-    metaDescription = List.empty,
     content = List(ArticleContent("<p>Bilde av en</p><p> en <em>pingvin</em> som vagger borover en gate</p>", "nb")),
-    visualElement = List.empty,
-    tags = List(Tag(List("fugl"), "nb")),
-    created = today.minusDays(4),
-    updated = today.minusDays(2),
     copyright = publicDomainCopyright.copy(creators = List(Author("Forfatter", "Pjolter")),
                                            processors = List(Author("Editorial", "Svims"))),
+    tags = List(Tag(List("fugl"), "nb")),
+    visualElement = List.empty,
+    introduction = List(ArticleIntroduction("Pingvinen", "nb")),
+    metaDescription = List.empty,
+    created = today.minusDays(4),
+    updated = today.minusDays(2),
+    published = today.minusDays(2),
     grepCodes = Seq("K456", "K123")
   )
 
   val article3: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(3),
     title = List(Title("Donald Duck kjører bil", "nb")),
+    content = List(ArticleContent("<p>Bilde av en en and</p><p> som <strong>kjører</strong> en rød bil.</p>", "nb")),
+    tags = List(Tag(List("and"), "nb")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Donald Duck", "nb")),
     metaDescription = List.empty,
-    content = List(ArticleContent("<p>Bilde av en en and</p><p> som <strong>kjører</strong> en rød bil.</p>", "nb")),
-    visualElement = List.empty,
-    tags = List(Tag(List("and"), "nb")),
     created = today.minusDays(4),
     updated = today.minusDays(1),
+    published = today.minusDays(1),
     grepCodes = Seq("K123")
   )
 
   val article4: Article = TestData.sampleArticleWithCopyrighted.copy(
     id = Option(4),
     title = List(Title("Superman er ute og flyr", "nb")),
-    introduction = List(ArticleIntroduction("Superman", "nb")),
-    metaDescription = List.empty,
     content =
       List(ArticleContent("<p>Bilde av en flygende mann</p><p> som <strong>har</strong> superkrefter.</p>", "nb")),
-    visualElement = List.empty,
     tags = List(Tag(List("supermann"), "nb")),
+    visualElement = List.empty,
+    introduction = List(ArticleIntroduction("Superman", "nb")),
+    metaDescription = List.empty,
     created = today.minusDays(4),
-    updated = today
+    updated = today,
+    published = today
   )
 
   val article5: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(5),
     title = List(Title("Hulken løfter biler", "nb")),
+    content = List(ArticleContent("<p>Bilde av hulk</p><p> som <strong>løfter</strong> en rød bil.</p>", "nb")),
+    tags = List(Tag(List("hulk"), "nb")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Hulken", "nb")),
     metaDescription = List.empty,
-    content = List(ArticleContent("<p>Bilde av hulk</p><p> som <strong>løfter</strong> en rød bil.</p>", "nb")),
-    visualElement = List.empty,
-    tags = List(Tag(List("hulk"), "nb")),
     created = today.minusDays(40),
     updated = today.minusDays(35),
+    published = today.minusDays(35),
     grepCodes = Seq("K456")
   )
 
   val article6: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(6),
     title = List(Title("Loke og Tor prøver å fange midgaardsormen", "nb")),
-    introduction = List(ArticleIntroduction("Loke og Tor", "nb")),
-    metaDescription = List.empty,
     content = List(
       ArticleContent("<p>Bilde av <em>Loke</em> og <em>Tor</em></p><p> som <strong>fisker</strong> fra Naglfar.</p>",
                      "nb")),
-    visualElement = List.empty,
     tags = List(Tag(List("Loke", "Tor", "Naglfar"), "nb")),
+    visualElement = List.empty,
+    introduction = List(ArticleIntroduction("Loke og Tor", "nb")),
+    metaDescription = List.empty,
     created = today.minusDays(30),
-    updated = today.minusDays(25)
+    updated = today.minusDays(25),
+    published = today.minusDays(25),
   )
 
   val article7: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(7),
     title = List(Title("Yggdrasil livets tre", "nb")),
+    content = List(ArticleContent("<p>Bilde av <em>Yggdrasil</em> livets tre med alle dyrene som bor i det.", "nb")),
+    tags = List(Tag(List("yggdrasil"), "nb")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Yggdrasil", "nb")),
     metaDescription = List.empty,
-    content = List(ArticleContent("<p>Bilde av <em>Yggdrasil</em> livets tre med alle dyrene som bor i det.", "nb")),
-    visualElement = List.empty,
-    tags = List(Tag(List("yggdrasil"), "nb")),
     created = today.minusDays(20),
-    updated = today.minusDays(15)
+    updated = today.minusDays(15),
+    published = today.minusDays(15),
   )
 
   val article8: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(8),
     title = List(Title("Baldur har mareritt", "nb")),
+    content = List(ArticleContent("<p>Bilde av <em>Baldurs</em> mareritt om Ragnarok.", "nb")),
+    tags = List(Tag(List("baldur"), "nb")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Baldur", "nb")),
     metaDescription = List.empty,
-    content = List(ArticleContent("<p>Bilde av <em>Baldurs</em> mareritt om Ragnarok.", "nb")),
-    visualElement = List.empty,
-    tags = List(Tag(List("baldur"), "nb")),
     created = today.minusDays(10),
     updated = today.minusDays(5),
+    published = today.minusDays(5),
     articleType = LearningResourceType.TopicArticle
   )
 
   val article9: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(9),
     title = List(Title("En Baldur har mareritt om Ragnarok", "nb")),
+    content = List(ArticleContent("<p>Bilde av <em>Baldurs</em> som har  mareritt.", "nb")),
+    tags = List(Tag(List("baldur"), "nb")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Baldur", "nb")),
     metaDescription = List.empty,
-    content = List(ArticleContent("<p>Bilde av <em>Baldurs</em> som har  mareritt.", "nb")),
-    visualElement = List.empty,
-    tags = List(Tag(List("baldur"), "nb")),
     created = today.minusDays(10),
     updated = today.minusDays(5),
+    published = today.minusDays(5),
     articleType = LearningResourceType.TopicArticle
   )
 
   val article10: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(10),
     title = List(Title("This article is in english", "en")),
+    content = List(ArticleContent("<p>Something something <em>english</em> What", "en")),
+    tags = List(Tag(List("englando"), "en")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Engulsk", "en")),
     metaDescription = List.empty,
-    content = List(ArticleContent("<p>Something something <em>english</em> What", "en")),
     metaImage = List(ArticleMetaImage("442", "alt", "en")),
-    visualElement = List.empty,
-    tags = List(Tag(List("englando"), "en")),
     created = today.minusDays(10),
     updated = today.minusDays(5),
+    published = today.minusDays(5),
     articleType = LearningResourceType.TopicArticle
   )
 
   val article11: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(11),
     title = List(Title("Katter", "nb"), Title("Cats", "en")),
+    content = List(ArticleContent("<p>Noe om en katt</p>", "nb"), ArticleContent("<p>Something about a cat</p>", "en")),
+    tags = List(Tag(List("ikkehund"), "nb"), Tag(List("notdog"), "en")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Katter er store", "nb"), ArticleIntroduction("Cats are big", "en")),
     metaDescription = List(MetaDescription("hurr durr ima sheep", "en")),
-    content = List(ArticleContent("<p>Noe om en katt</p>", "nb"), ArticleContent("<p>Something about a cat</p>", "en")),
-    visualElement = List.empty,
-    tags = List(Tag(List("ikkehund"), "nb"), Tag(List("notdog"), "en")),
     created = today.minusDays(10),
     updated = today.minusDays(5),
+    published = today.minusDays(5),
     articleType = LearningResourceType.TopicArticle
   )
 
   val article12: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(12),
     title = List(Title("Ekstrastoff", "nb")),
+    content = List(ArticleContent("", "nb")),
+    tags = List(Tag(List(""), "nb")),
+    visualElement = List.empty,
     introduction = List(ArticleIntroduction("Ekstra", "nb")),
     metaDescription = List(MetaDescription("", "nb")),
-    content = List(ArticleContent("", "nb")),
-    visualElement = List.empty,
-    tags = List(Tag(List(""), "nb")),
     created = today.minusDays(10),
     updated = today.minusDays(5),
+    published = today.minusDays(5),
     articleType = LearningResourceType.Article
   )
 
@@ -385,6 +404,7 @@ object TestData {
     created = today,
     updated = today,
     updatedBy = "",
+    published = today,
     articleType = LearningResourceType.Article,
     grepCodes = Seq.empty
   )

--- a/src/test/scala/no/ndla/searchapi/integration/ArticleApiClientTest.scala
+++ b/src/test/scala/no/ndla/searchapi/integration/ArticleApiClientTest.scala
@@ -72,6 +72,7 @@ class ArticleApiClientTest extends UnitSuite with TestEnvironment {
         today,
         today,
         "ndalId54321",
+        today,
         LearningResourceType.Article,
         grepCodes = Seq()
       )


### PR DESCRIPTION
Article-api trigger indeksering ved publisering, og når search-api returnerer resultat av indeksering klarer ikkje article-api å parse svaret fordi published ikkje finnes i responsen. Verdien brukes ikkje til noko her, den berre tas i mot og returneres.