### PR TITLE
#2176: Multi queries for supporting compound words

### DIFF
--- a/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -210,5 +210,26 @@ trait SearchService {
       }
     }
 
+    /** Takes in a string and returns strins with removed whitespaces
+      * Example: "helse søster hjelp" would return Seq("helsesøster hjelp", "helse søsterhjelp")
+      * Used to search for misspelled compound words (Its hard to determine which words to combine so we combine all of them).
+      */
+    protected def generateQueryStringsWithRemovedWhitespaces(qs: String): Seq[String] = {
+      if (qs.contains(" ")) {
+        val trimmed = qs.trim()
+        val numSpaces = trimmed.count(_ == ' ')
+
+        (0 until numSpaces)
+          .foldLeft((0, Seq.empty[String])) {
+            case (acc, _) => {
+              val lastIdx = acc._1
+              val idxToReplace = trimmed.indexOf(" ", lastIdx + 1)
+              (idxToReplace, acc._2 :+ trimmed.patch(idxToReplace, "", 1))
+            }
+          }
+          ._2
+      } else { Seq.empty }
+    }
+
   }
 }

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -720,6 +720,15 @@ class MultiDraftSearchServiceTest extends IntegrationSuite with TestEnvironment 
     search.suggestions.head.suggestions.head.text should equal("bil")
   }
 
+  test("Search with whitespace matches resources with compound words") {
+    val Success(search) = multiDraftSearchService.matchingQuery(
+      multiDraftSearchSettings.copy(query = Some("midgaards ormen"))
+    )
+
+    search.results.head.id should be(6)
+    search.totalCount should be(1)
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -570,6 +570,15 @@ class MultiSearchServiceTest extends IntegrationSuite with TestEnvironment {
     search3.results.map(_.id) should be(Seq(1, 2, 3, 5))
   }
 
+  test("Search with whitespace matches resources with compound words") {
+    val Success(search) = multiSearchService.matchingQuery(
+      searchSettings.copy(query = Some("midgaards ormen"))
+    )
+
+    search.results.head.id should be(6)
+    search.totalCount should be(1)
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false


### PR DESCRIPTION
Fixes NDLANO/Issues#2176

Jeg elsker ikke måten jeg løser dette på. 
Kan hende søk med mange mellomrom blir litt dyrt (Skal gjøre en benchmark før jeg merger).

Det vi gjør er å fjerne alle mellomrom (1 og 1) og lager queries uten hvert mellomrom.

Så om man søker på "helse søster hjelp" så vil man få en query som bruker `helse søster hjelp` som vanlig, men man vil også generere en query for `helsesøster hjelp` og `helse søsterhjelp`.

Et alternativ er å bare fjerne all whitespace fra en query#2, men da vil jo fort søk som `helse søster hjelp` bli til `helsesøsterhjelp` og ikke få noen treff i det hele tatt.


Et annet alternativ (som sikkert _eeeegentlig_ er det beste er å få til en wordlist og bruke https://www.elastic.co/guide/en/elasticsearch/reference/6.8/analysis-compound-word-tokenfilter.html slik at vi kan indeksere alle.

Jeg fant [denne ordboken](http://www.nb.no/sbfil/leksikalske_databaser/leksikon/no.leksikon.tar.gz) som inneholder masse sammensetninger av ord som jeg _tror_ vi kunne brukt til å lage en ordliste for bruk med compound word tokenfilteret i elasticsearch. Får se hvor ille benchmarken blir ¯\_(ツ)_/¯
