### PR TITLE
Add filterid to filter results

### DIFF
--- a/src/main/scala/no/ndla/searchapi/model/api/ApiTaxonomyContext.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/ApiTaxonomyContext.scala
@@ -15,6 +15,7 @@ import scala.annotation.meta.field
 case class ApiTaxonomyContext(
     @(ApiModelProperty @field)(description = "Id of the taoxonomy object") id: String,
     @(ApiModelProperty @field)(description = "Name of the subject this context is in") subject: String,
+    @(ApiModelProperty @field)(description = "Id of the subject this context is in") subjectId: String,
     @(ApiModelProperty @field)(description = "Path to the resource in this context") path: String,
     @(ApiModelProperty @field)(description = "Breadcrumbs of path to the resource in this context") breadcrumbs: List[
       String],

--- a/src/main/scala/no/ndla/searchapi/model/api/TaxonomyContextFilter.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/TaxonomyContextFilter.scala
@@ -7,4 +7,4 @@
 
 package no.ndla.searchapi.model.api
 
-case class TaxonomyContextFilter(name: String, relevance: String)
+case class TaxonomyContextFilter(id: String, name: String, relevance: String)

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -577,6 +577,7 @@ trait SearchConverterService {
       ApiTaxonomyContext(
         id = context.id,
         subject = subjectName,
+        subjectId = context.subjectId,
         path = context.path,
         breadcrumbs = breadcrumbs,
         filters = filters,

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -591,10 +591,7 @@ trait SearchConverterService {
       val name = findByLanguageOrBestEffort(filter.name.languageValues, language).map(_.value).getOrElse("")
       val relevance = findByLanguageOrBestEffort(filter.relevance.languageValues, language).map(_.value).getOrElse("")
 
-      api.TaxonomyContextFilter(
-        name,
-        relevance
-      )
+      api.TaxonomyContextFilter(filter.filterId, name, relevance)
     }
 
     private def compareId(contentUri: String, id: Long, `type`: String): Boolean = {


### PR DESCRIPTION
Legger på filterid fordi dette trengs for å kunne presentere urler med filter i søkeresultat. I dag returneres kun navnet på filteret og det gjør det vanskelig å ha korrekt url.