### PR TITLE
#2226: Only create initial scroll-context when provided with '0', 'start', 'first' or 'initial'

### DIFF
--- a/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -57,7 +57,8 @@ object SearchApiProperties extends LazyLogging {
   val MaxPageSize = 10000
   val IndexBulkSize = 100
   val ElasticSearchIndexMaxResultWindow = 10000
-  val ElasticSearchScrollKeepAlive = "10s"
+  val ElasticSearchScrollKeepAlive = "1m"
+  val InitialScrollContextKeywords = List("0", "initial", "start", "first")
 
   val ExternalApiUrls: Map[String, String] = Map(
     "article-api" -> s"$Domain/article-api/v2/articles",

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -145,9 +145,9 @@ trait SearchController {
       "search-context",
       s"""A unique string obtained from a search you want to keep scrolling in. To obtain one from a search, provide one of the following values: ${InitialScrollContextKeywords
            .mkString("[", ",", "]")}.
-          |When scrolling the parameters from the initial search is used, except in the case of '${this.language.paramName}' and '${this.fallback.paramName}'.
-          |The value may change between scrolls. Always use the one in the latest scroll result (The context if unused dies after $ElasticSearchScrollKeepAlive).
-          |If you are not scrolling past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.paramName}' and '${this.pageSize.paramName}' instead.
+          |When scrolling, the parameters from the initial search is used, except in the case of '${this.language.paramName}' and '${this.fallback.paramName}'.
+          |This value may change between scrolls. Always use the one in the latest scroll result (The context, if unused, dies after $ElasticSearchScrollKeepAlive).
+          |If you are not paginating past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.paramName}' and '${this.pageSize.paramName}' instead.
           |""".stripMargin
     )
 

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -143,14 +143,12 @@ trait SearchController {
 
     private val scrollId = Param[Option[String]](
       "search-context",
-      s"""A search context retrieved from the response header of a previous search.
-        |To get the initial one from a search supply search-context equal any of the following ${InitialScrollContextKeywords
+      s"""A unique string obtained from a search you want to keep scrolling in. To obtain one from a search, provide one of the following values: ${InitialScrollContextKeywords
            .mkString("[", ",", "]")}.
-        |If search-context is specified, all other query parameters, except '${this.language.paramName}' and '${this.fallback.paramName}' are ignored
-        |For the rest of the parameters the original search of the search-context is used.
-        |The search context may change between scrolls. Always use the most recent one (The context if unused dies after $ElasticSearchScrollKeepAlive).
-        |Used to enable scrolling past $ElasticSearchIndexMaxResultWindow results.
-      """.stripMargin
+          |When scrolling the parameters from the initial search is used, except in the case of '${this.language.paramName}' and '${this.fallback.paramName}'.
+          |The value may change between scrolls. Always use the one in the latest scroll result (The context if unused dies after $ElasticSearchScrollKeepAlive).
+          |If you are not scrolling past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.paramName}' and '${this.pageSize.paramName}' instead.
+          |""".stripMargin
     )
 
     private val statusFilter = Param[Option[Seq[String]]](

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -31,4 +31,5 @@ case class MultiDraftSearchSettings(
     statusFilter: List[ArticleStatus.Value],
     userFilter: List[String],
     grepCodes: List[String],
+    shouldScroll: Boolean
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -26,5 +26,6 @@ case class SearchSettings(
     supportedLanguages: List[String],
     relevanceIds: List[String],
     contextIds: List[String],
-    grepCodes: List[String]
+    grepCodes: List[String],
+    shouldScroll: Boolean
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -106,7 +106,9 @@ trait MultiDraftSearchService {
 
         // Only add scroll param if it is first page
         val searchWithScroll =
-          if (startAt != 0) { searchToExecute } else { searchToExecute.scroll(ElasticSearchScrollKeepAlive) }
+          if (startAt == 0 && settings.shouldScroll) {
+            searchToExecute.scroll(ElasticSearchScrollKeepAlive)
+          } else { searchToExecute }
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1100,7 +1100,8 @@ object TestData {
     supportedLanguages = List.empty,
     relevanceIds = List.empty,
     contextIds = List.empty,
-    grepCodes = List.empty
+    grepCodes = List.empty,
+    shouldScroll = false
   )
 
   val multiDraftSearchSettings = MultiDraftSearchSettings(
@@ -1122,7 +1123,8 @@ object TestData {
     relevanceIds = List.empty,
     statusFilter = List.empty,
     userFilter = List.empty,
-    grepCodes = List.empty
+    grepCodes = List.empty,
+    shouldScroll = false
   )
 
   val searchableResourceTypes = List(

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -604,7 +604,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite with TestEnvironment 
     val ids = idsForLang("all").sorted.sliding(pageSize, pageSize).toList
 
     val Success(initialSearch) = multiDraftSearchService.matchingQuery(
-      multiDraftSearchSettings.copy(language = Language.AllLanguages, pageSize = pageSize))
+      multiDraftSearchSettings.copy(language = Language.AllLanguages, pageSize = pageSize, shouldScroll = true))
 
     val Success(scroll1) = multiDraftSearchService.scroll(initialSearch.scrollId.get, "all", fallback = true)
     val Success(scroll2) = multiDraftSearchService.scroll(scroll1.scrollId.get, "all", fallback = true)


### PR DESCRIPTION
Relates to NDLANO/Issues#2226