### PR TITLE
Filter out contexts for invisible subjects

### DIFF
--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -448,7 +448,8 @@ trait SearchController {
             asQueryParam(languageFilter),
             asQueryParam(relevanceFilter),
             asQueryParam(contextFilters),
-            asQueryParam(scrollId)
+            asQueryParam(scrollId),
+            asQueryParam(grepCodes)
           )
           .responseMessages(response500))
     ) {

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -705,6 +705,7 @@ trait SearchConverterService {
     }
 
     private def getResourceTaxonomyContexts(resource: Resource,
+                                            filterVisibles: Boolean,
                                             bundle: TaxonomyBundle): Try[List[SearchableTaxonomyContext]] = {
       val topicsConnections = bundle.topicResourceConnections.filter(_.resourceId == resource.id)
       val topics = bundle.topics.filter(topic => topicsConnections.map(_.topicid).contains(topic.id))
@@ -720,7 +721,13 @@ trait SearchConverterService {
               val subjectConnections = bundle.subjectTopicConnections.filter(_.topicid == topic.id)
               val subjects = bundle.subjects.filter(subject => subjectConnections.map(_.subjectid).contains(subject.id))
 
-              subjects.map(subject => {
+              val filteredSubjects = if (filterVisibles) {
+                subjects.filter(subject => subject.metadata.exists(_.visible))
+              } else {
+                subjects
+              }
+
+              filteredSubjects.map(subject => {
                 val contextFilters = getFilters(resource, subject, bundle, bundle.resourceFilterConnections)
                 val pathIds = (resource.id +: topicPath :+ subject.id).reverse
 
@@ -804,7 +811,9 @@ trait SearchConverterService {
       (resourceTypes ++ subParents).distinct
     }
 
-    private def getTopicTaxonomyContexts(topic: Topic, bundle: TaxonomyBundle): Try[List[SearchableTaxonomyContext]] = {
+    private def getTopicTaxonomyContexts(topic: Topic,
+                                         filterVisibles: Boolean,
+                                         bundle: TaxonomyBundle): Try[List[SearchableTaxonomyContext]] = {
       val topicsConnections = bundle.topicResourceConnections.filter(_.resourceId == topic.id)
       val topics = bundle.topics.filter(topic => topicsConnections.map(_.topicid).contains(topic.id)) :+ topic
       val parentTopicsAndPaths = topics.flatMap(t => getParentTopicsAndPaths(t, bundle, List(t.id)))
@@ -819,7 +828,13 @@ trait SearchConverterService {
               val subjectConnections = bundle.subjectTopicConnections.filter(_.topicid == parentTopic.id)
               val subjects = bundle.subjects.filter(subject => subjectConnections.map(_.subjectid).contains(subject.id))
 
-              subjects.map(subject => {
+              val filteredSubjects = if (filterVisibles) {
+                subjects.filter(subject => subject.metadata.exists(_.visible))
+              } else {
+                subjects
+              }
+
+              filteredSubjects.map(subject => {
                 val contextFilters = getFilters(topic, subject, bundle, bundle.topicFilterConnections)
                 val pathIds = (topicPath :+ subject.id).reverse
 
@@ -853,14 +868,15 @@ trait SearchConverterService {
                                     filterVisibles: Boolean): Try[List[SearchableTaxonomyContext]] = {
       val (resources, topics) = getTaxonomyResourceAndTopicsForId(id, bundle, taxonomyType)
       val resourceContexts = if (filterVisibles) {
-        filterByVisibility(resources, bundle).map(resource => getResourceTaxonomyContexts(resource, bundle))
+        filterByVisibility(resources, bundle).map(resource =>
+          getResourceTaxonomyContexts(resource, filterVisibles, bundle))
       } else {
-        resources.map(resource => getResourceTaxonomyContexts(resource, bundle))
+        resources.map(resource => getResourceTaxonomyContexts(resource, filterVisibles, bundle))
       }
       val topicContexts = if (filterVisibles) {
-        filterByVisibility(topics, bundle).map(topic => getTopicTaxonomyContexts(topic, bundle))
+        filterByVisibility(topics, bundle).map(topic => getTopicTaxonomyContexts(topic, filterVisibles, bundle))
       } else {
-        topics.map(topic => getTopicTaxonomyContexts(topic, bundle))
+        topics.map(topic => getTopicTaxonomyContexts(topic, filterVisibles, bundle))
       }
 
       val all = resourceContexts ++ topicContexts

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -896,12 +896,7 @@ trait SearchConverterService {
     }
 
     private def filterByVisibility[T <: TaxonomyElement](elementsToFilter: List[T], bundle: TaxonomyBundle): List[T] = {
-      val isVisible = (e: TaxonomyElement) => e.metadata.exists(_.visible)
-      val hasVisibleSubject = (e: TaxonomyElement) => bundle.getSubject(e.path).exists(isVisible)
-
-      elementsToFilter
-        .filter(isVisible)
-        .filter(hasVisibleSubject)
+      elementsToFilter.filter((e: TaxonomyElement) => e.metadata.exists(_.visible))
     }
 
     private[service] def getGrepContexts(grepCodes: Seq[String], bundle: GrepBundle): List[SearchableGrepContext] = {

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -892,41 +892,55 @@ object TestData {
   )
 
   val resources = List(
-    Resource("urn:resource:1",
-             article1.title.head.title,
-             Some(s"urn:article:${article1.id.get}"),
-             Some("/subject:1/topic:1/resource:1"),
-             visibleMetadata),
-    Resource("urn:resource:2",
-             article2.title.head.title,
-             Some(s"urn:article:${article2.id.get}"),
-             Some("/subject:1/topic:1/resource:2"),
-             visibleMetadata),
-    Resource("urn:resource:3",
-             article3.title.head.title,
-             Some(s"urn:article:${article3.id.get}"),
-             Some("/subject:1/topic:3/resource:3"),
-             visibleMetadata),
-    Resource("urn:resource:4",
-             article4.title.head.title,
-             Some(s"urn:article:${article4.id.get}"),
-             Some("/subject:1/topic:1/topic:2/resource:4"),
-             visibleMetadata),
-    Resource("urn:resource:5",
-             article5.title.head.title,
-             Some(s"urn:article:${article5.id.get}"),
-             Some("/subject:2/topic:4/resource:5"),
-             visibleMetadata),
-    Resource("urn:resource:6",
-             article6.title.head.title,
-             Some(s"urn:article:${article6.id.get}"),
-             Some("/subject:2/topic:4/resource:6"),
-             visibleMetadata),
-    Resource("urn:resource:7",
-             article7.title.head.title,
-             Some(s"urn:article:${article7.id.get}"),
-             Some("/subject:2/topic:4/resource:7"),
-             visibleMetadata),
+    Resource(
+      "urn:resource:1",
+      article1.title.head.title,
+      Some(s"urn:article:${article1.id.get}"),
+      Some("/subject:1/topic:1/resource:1"),
+      visibleMetadata
+    ),
+    Resource(
+      "urn:resource:2",
+      article2.title.head.title,
+      Some(s"urn:article:${article2.id.get}"),
+      Some("/subject:1/topic:1/resource:2"),
+      visibleMetadata
+    ),
+    Resource(
+      "urn:resource:3",
+      article3.title.head.title,
+      Some(s"urn:article:${article3.id.get}"),
+      Some("/subject:1/topic:3/resource:3"),
+      visibleMetadata
+    ),
+    Resource(
+      "urn:resource:4",
+      article4.title.head.title,
+      Some(s"urn:article:${article4.id.get}"),
+      Some("/subject:1/topic:1/topic:2/resource:4"),
+      visibleMetadata
+    ),
+    Resource(
+      "urn:resource:5",
+      article5.title.head.title,
+      Some(s"urn:article:${article5.id.get}"),
+      Some("/subject:2/topic:4/resource:5"),
+      visibleMetadata
+    ),
+    Resource(
+      "urn:resource:6",
+      article6.title.head.title,
+      Some(s"urn:article:${article6.id.get}"),
+      Some("/subject:2/topic:4/resource:6"),
+      visibleMetadata
+    ),
+    Resource(
+      "urn:resource:7",
+      article7.title.head.title,
+      Some(s"urn:article:${article7.id.get}"),
+      Some("/subject:2/topic:4/resource:7"),
+      visibleMetadata
+    ),
     Resource(
       "urn:resource:8",
       learningPath1.title.head.title,
@@ -962,11 +976,13 @@ object TestData {
       Some("/subject:2/topic:4/resource:5"),
       visibleMetadata
     ),
-    Resource("urn:resource:13",
-             article12.title.head.title,
-             Some(s"urn:article:${article12.id.get}"),
-             Some("/subject:2/topic:4/resource:13"),
-             visibleMetadata)
+    Resource(
+      "urn:resource:13",
+      article12.title.head.title,
+      Some(s"urn:article:${article12.id.get}"),
+      Some("/subject:2/topic:4/resource:13"),
+      visibleMetadata
+    )
   )
 
   val topics = List(
@@ -1020,7 +1036,8 @@ object TestData {
     TopicResourceConnection("urn:topic:2", "urn:resource:11", "urn:topic-resource:13", primary = true, 1),
     TopicResourceConnection("urn:topic:4", "urn:resource:12", "urn:topic-resource:14", primary = true, 1),
     TopicResourceConnection("urn:topic:1", "urn:resource:13", "urn:topic-resource:15", primary = true, 1),
-    TopicResourceConnection("urn:topic:4", "urn:resource:13", "urn:topic-resource:16", primary = true, 1)
+    TopicResourceConnection("urn:topic:4", "urn:resource:13", "urn:topic-resource:16", primary = true, 1),
+    TopicResourceConnection("urn:topic:5", "urn:resource:1", "urn:topic-resource:17", primary = true, 1)
   )
 
   val topicSubtopicConnections = List(

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -896,7 +896,7 @@ object TestData {
       "urn:resource:1",
       article1.title.head.title,
       Some(s"urn:article:${article1.id.get}"),
-      Some("/subject:1/topic:1/resource:1"),
+      Some("/subject:3/topic:5/resource:1"),
       visibleMetadata
     ),
     Resource(

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -417,8 +417,8 @@ class MultiDraftSearchServiceTest extends IntegrationSuite with TestEnvironment 
   test("That filtering for invisible subjects returns all drafts with any of listed subjects") {
     val Success(search) =
       multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(subjects = List("urn:subject:3")))
-    search.totalCount should be(1)
-    search.results.map(_.id) should be(Seq(15))
+    search.totalCount should be(2)
+    search.results.map(_.id) should be(Seq(1, 15))
   }
 
   test("That filtering for resource-types works as expected") {

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -373,6 +373,8 @@ class MultiSearchServiceTest extends IntegrationSuite with TestEnvironment {
       multiSearchService.matchingQuery(searchSettings.copy(subjects = List("urn:subject:2"), language = "all"))
     search.totalCount should be(7)
     search.results.head.contexts.length should be(2)
+    search.results.head.contexts
+      .map(_.subjectId) should be(List("urn:subject:1", "urn:subject:2")) // urn:subject:3 is not visible
     search.results.map(_.id) should be(Seq(1, 5, 5, 6, 7, 11, 12))
   }
 

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -372,6 +372,7 @@ class MultiSearchServiceTest extends IntegrationSuite with TestEnvironment {
     val Success(search) =
       multiSearchService.matchingQuery(searchSettings.copy(subjects = List("urn:subject:2"), language = "all"))
     search.totalCount should be(7)
+    search.results.head.contexts.length should be(2)
     search.results.map(_.id) should be(Seq(1, 5, 5, 6, 7, 11, 12))
   }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2236

En ressurs som er knytta til to subjects, en synlig og en usynlig, blir indeksert i søket med begge kontekstene tilgjengelig fordi filtering på synlighet kun tar høgde for subject i path-parameteren, og kun på den pathen som kjem først. Dersom synlig path kjem først blir begge kontekstene med, men om den usynlige pathen kjem først vises den uten kontekster.

Endringa bryr seg ikkje om path-parameteren, men sjekker heller om subject for conteksten er synlig i filteringa.