### PR TITLE
#2279: Handle null as LanguageValue in serializer to handle taxonomy filter name = null

### DIFF
--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableLanguageFormats.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableLanguageFormats.scala
@@ -28,8 +28,9 @@ class SearchableLanguageValuesSerializer
           SearchableLanguageValues(langs)
       }, {
         case searchableLanguageValues: SearchableLanguageValues =>
-          val langValues = searchableLanguageValues.languageValues.map(lv => {
-            JField(lv.language, JString(lv.value))
+          val langValues = searchableLanguageValues.languageValues.flatMap(lv => {
+            Option(lv.value)
+              .map(str => JField(lv.language, JString(str)))
           })
           JObject(langValues: _*)
       }))
@@ -50,9 +51,11 @@ class SearchableLanguageListSerializer
       }, {
         case searchableLanguageList: SearchableLanguageList =>
           implicit val formats: Formats = SearchableLanguageFormats.JSonFormats
-          val langValues = searchableLanguageList.languageValues.map(lv => {
-            val tags = Extraction.decompose(lv.value)
-            JField(lv.language, tags)
+          val langValues = searchableLanguageList.languageValues.flatMap(lv => {
+            Option(lv.value).map(v => {
+              val tags = Extraction.decompose(v)
+              JField(lv.language, tags)
+            })
           })
           JObject(langValues: _*)
 

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -596,11 +596,7 @@ trait SearchConverterService {
     }
 
     private def compareId(contentUri: String, id: Long, `type`: String): Boolean = {
-      val split = contentUri.split(':')
-      split match {
-        case Array(_, cType: String, cId: String) => id.toString == cId && cType == `type`
-        case _                                    => false
-      }
+      contentUri == s"urn:${`type`}:$id"
     }
 
     private def getContextType(resourceId: String, contentUri: Option[String]): Try[LearningResourceType.Value] = {
@@ -950,20 +946,14 @@ trait SearchConverterService {
     }
 
     private def getTaxonomyResourceAndTopicsForId(id: Long, bundle: TaxonomyBundle, taxonomyType: String) = {
+      val idMatchingTaxonomy = (elem: TaxonomyElement) => elem.contentUri.exists(compareId(_, id, taxonomyType))
+
       val resources = bundle.resources
-        .filter(resource =>
-          resource.contentUri match {
-            case Some(contentUri) => compareId(contentUri, id, taxonomyType)
-            case None             => false
-        })
+        .filter(idMatchingTaxonomy)
         .distinct
 
       val topics = bundle.topics
-        .filter(topic =>
-          topic.contentUri match {
-            case Some(contentUri) => compareId(contentUri, id, taxonomyType)
-            case None             => false
-        })
+        .filter(idMatchingTaxonomy)
         .distinct
 
       (resources, topics)

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1154,7 +1154,7 @@ object TestData {
                                    SearchableLanguageValues(Seq(LanguageValue("nb", "Fagartikkel"))))
   )
 
-  val searchableTaxonomyContexts = List(
+  val singleSearchableTaxonomyContext =
     SearchableTaxonomyContext(
       id = "urn:resource:101",
       subjectId = "urn:subject:1",
@@ -1175,5 +1175,8 @@ object TestData {
       resourceTypes = searchableResourceTypes,
       parentTopicIds = List("urn:topic:1")
     )
+
+  val searchableTaxonomyContexts = List(
+    singleSearchableTaxonomyContext
   )
 }

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -82,4 +82,84 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
     deserialized should be(original)
   }
 
+  test(
+    "That serializing a SearchableArticle with null values to json and deserializing back does not throw an exception") {
+    implicit val formats: Formats = SearchableLanguageFormats.JSonFormats
+
+    val titles =
+      SearchableLanguageValues(Seq(LanguageValue("nb", "Christian Tut"), LanguageValue("en", "Christian Honk")))
+
+    val contents = SearchableLanguageValues(
+      Seq(
+        LanguageValue("nn", "Eg kjøyrar rundt i min fine bil"),
+        LanguageValue("nb", "Jeg kjører rundt i tutut"),
+        LanguageValue("en", "I'm in my mums car wroomwroom")
+      ))
+
+    val visualElements = SearchableLanguageValues(Seq(LanguageValue("nn", "image"), LanguageValue("nb", "image")))
+
+    val introductions = SearchableLanguageValues(
+      Seq(
+        LanguageValue("en", "Wroom wroom")
+      ))
+
+    val metaDescriptions = SearchableLanguageValues(
+      Seq(
+        LanguageValue("nb", "Mammas bil")
+      ))
+
+    val tags = SearchableLanguageList(
+      Seq(
+        LanguageValue("en", Seq("Mum", "Car", "Wroom"))
+      ))
+
+    val embedAttrs = SearchableLanguageList(
+      Seq(
+        LanguageValue("nb", Seq("En norsk", "To norsk")),
+        LanguageValue("en", Seq("One english"))
+      ))
+
+    val metaImages = List(ArticleMetaImage("1", "alt", "nb"))
+    val filterWithNullName =
+      SearchableTaxonomyFilter(
+        filterId = "urn:filter:1",
+        name = SearchableLanguageValues(Seq(LanguageValue("nb", null))),
+        relevanceId = "urn:relevance:core",
+        relevance = SearchableLanguageValues(Seq(LanguageValue("nb", "Kjernestoff")))
+      )
+
+    val original = SearchableArticle(
+      id = 100,
+      title = titles,
+      content = contents,
+      visualElement = visualElements,
+      introduction = introductions,
+      metaDescription = metaDescriptions,
+      tags = tags,
+      lastUpdated = TestData.today,
+      license = "by-sa",
+      authors = List("Jonas", "Papi"),
+      articleType = LearningResourceType.Article.toString,
+      metaImage = metaImages,
+      defaultTitle = Some("Christian Tut"),
+      supportedLanguages = List("en", "nb", "nn"),
+      contexts = List(singleSearchableTaxonomyContext.copy(filters = List(filterWithNullName))),
+      grepContexts =
+        List(SearchableGrepContext("K123", Some("some title")), SearchableGrepContext("K456", Some("some title 2"))),
+      traits = List.empty,
+      embedAttributes = embedAttrs
+    )
+
+    val json = write(original)
+    val deserialized = read[SearchableArticle](json)
+
+    val expected = original.copy(
+      contexts = List(
+        singleSearchableTaxonomyContext.copy(
+          filters = List(filterWithNullName.copy(name = SearchableLanguageValues(Seq.empty)))))
+    )
+
+    deserialized should be(expected)
+  }
+
 }


### PR DESCRIPTION
- Handle null as LanguageValue in serializer to handle taxonomy filter name = null (And other potential `null` values in LanguageValue's)
- Optimize some taxonomy converter functions for better performance when indexing
