### PR TITLE
#2291 + #2289: Adds scoring and highlights to search hits and stricter decompounding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.log
 /.idea
 /.history
+/.vscode
 /target
 **/target
 **/.DS_Store

--- a/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -11,6 +11,13 @@ import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
 
+@ApiModel(description = "Object describing matched field with matching words emphasized")
+case class HighlightedField(
+    @(ApiModelProperty @field)(description = "Field that matched") field: String,
+    @(ApiModelProperty @field)(description = "List of segments that matched in `field`") matches: Seq[String]
+)
+
+// format: off
 @ApiModel(description = "Short summary of information about the resource")
 case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "The unique id of the resource") id: Long,
@@ -20,8 +27,10 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "Url pointing to the resource") url: String,
     @(ApiModelProperty @field)(description = "Contexts of the resource") contexts: List[ApiTaxonomyContext],
     @(ApiModelProperty @field)(description = "Languages the resource exists in") supportedLanguages: Seq[String],
-    @(ApiModelProperty @field)(description =
-      "Learning resource type, either 'standard', 'topic-article' or 'learningpath'") learningResourceType: String,
+    @(ApiModelProperty @field)(description = "Learning resource type, either 'standard', 'topic-article' or 'learningpath'") learningResourceType: String,
     @(ApiModelProperty @field)(description = "Status information of the resource") status: Option[Status],
-    @(ApiModelProperty @field)(description = "Traits for the resource") traits: List[String]
+    @(ApiModelProperty @field)(description = "Traits for the resource") traits: List[String],
+    @(ApiModelProperty @field)(description = "Relevance score. The higher the score, the better the document matches your search criteria.") score: Float,
+    @(ApiModelProperty @field)(description = "List of objects describing matched field with matching words emphasized") highlights: List[HighlightedField]
 )
+// format: on

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -44,14 +44,14 @@ trait SearchService {
       val articleType = SearchApiProperties.SearchDocuments(SearchType.Articles)
       val draftType = SearchApiProperties.SearchDocuments(SearchType.Drafts)
       val learningPathType = SearchApiProperties.SearchDocuments(SearchType.LearningPaths)
-      hit.`type` match {
-        case `articleType` =>
-          searchConverterService.articleHitAsMultiSummary(hit.sourceAsString, language)
-        case `draftType` =>
-          searchConverterService.draftHitAsMultiSummary(hit.sourceAsString, language)
-        case `learningPathType` =>
-          searchConverterService.learningpathHitAsMultiSummary(hit.sourceAsString, language)
+
+      val convertFunc = hit.`type` match {
+        case `articleType`      => searchConverterService.articleHitAsMultiSummary _
+        case `draftType`        => searchConverterService.draftHitAsMultiSummary _
+        case `learningPathType` => searchConverterService.learningpathHitAsMultiSummary _
       }
+
+      convertFunc(hit, language)
     }
 
     def buildSimpleStringQueryForField(
@@ -66,12 +66,12 @@ trait SearchService {
           (acc, cur) =>
             acc
               .field(s"$field.${cur.lang}", boost)
-              .field(s"$field.${cur.lang}.decompounded")
+              .field(s"$field.${cur.lang}.decompounded", 0.1)
         )
       } else {
         simpleStringQuery(query)
           .field(s"$field.$language", boost)
-          .field(s"$field.$language.decompounded")
+          .field(s"$field.$language.decompounded", 0.1)
       }
     }
 

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -172,7 +172,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite with TestEnvironment 
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(query = Some("bil"), sort = Sort.ByRelevanceDesc))
     results.totalCount should be(3)
-    results.results.map(_.id) should be(Seq(1, 5, 3))
+    results.results.map(_.id) should be(Seq(5, 1, 3))
   }
 
   test("That search combined with filter by id only returns documents matching the query with one of the given ids") {
@@ -261,9 +261,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite with TestEnvironment 
   test("That searching with NOT returns expected results") {
     val Success(search1) = multiDraftSearchService.matchingQuery(
       multiDraftSearchSettings.copy(query = Some("-flaggermusmann + (bil + bilde)"), sort = Sort.ByTitleAsc))
-    // 1 is matched even if flaggermusmann exists in the document because the decompounded field does not contain flaggermusmann and causes a match
-    // This is unwanted, but as of now i can not see a workaround
-    search1.results.map(_.id) should equal(Seq(1, 3, 5))
+    search1.results.map(_.id) should equal(Seq(3, 5))
 
     val Success(search2) =
       multiDraftSearchService.matchingQuery(

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -239,9 +239,7 @@ class MultiSearchServiceTest extends IntegrationSuite with TestEnvironment {
   test("Searching with NOT returns expected results") {
     val Success(search1) = multiSearchService.matchingQuery(
       searchSettings.copy(Some("bil + bilde + -flaggermusmann"), sort = Sort.ByTitleAsc))
-    // 1 is matched even if flaggermusmann exists in the document because the decompounded field does not contain flaggermusmann and causes a match
-    // This is unwanted, but as of now i can not see a workaround
-    search1.results.map(_.id) should equal(Seq(1, 3, 5))
+    search1.results.map(_.id) should equal(Seq(3, 5))
 
     val Success(search2) =
       multiSearchService.matchingQuery(searchSettings.copy(Some("bil + -hulken"), sort = Sort.ByTitleAsc))


### PR DESCRIPTION
Fixes NDLANO/Issues#2289
Kanskje fixes NDLANO/Issues#2291

- Legger til elasticsearch score og highlights til søkeresultatene
  - Kan testes ved å spinne opp api'et og gjøre et søk og se på responsen :smile: 

- Gjør decompounding av ord litt strengere som vil gi oss færre resultater, men syns det er vanskelig å vite hva vi egentlig har lyst på her (Ref https://github.com/NDLANO/Issues/issues/2291#issuecomment-716526026)

Eksempel på scoring og highlights:
```
{
  "id": 18327,
  ...
  "score": 39.289825439453125,
  "highlights": [
    {
      "field": "embedAttributes.nn",
      "matches": [
        "Publikum på <em>fotballkamp</em> i England. Foto."
      ]
    },
    {
      "field": "content.nb",
      "matches": [
        "Hun kan for eksempel observere hvordan deltakerne på en <em>fotballkamp</em> kler seg, hvor ofte elever tar opp"
      ]
    },
    {
      "field": "content.nn.decompounded",
      "matches": [
        "Ho kan til dømes observere korleis deltakarane på ein <em>fotballkamp</em> kler seg, kor ofte elevar tek opp telefonane"
      ]
    },
    {
      "field": "embedAttributes.nb",
      "matches": [
        "Publikum på <em>fotballkamp</em> i England. Foto."
      ]
    },
    {
      "field": "content.nn",
      "matches": [
        "Ho kan til dømes observere korleis deltakarane på ein <em>fotballkamp</em> kler seg, kor ofte elevar tek opp telefonane"
      ]
    },
    {
      "field": "content.nb.decompounded",
      "matches": [
        "Hun kan for eksempel observere hvordan deltakerne på en <em>fotballkamp</em> kler seg, hvor ofte elever tar opp"
      ]
    },
    {
      "field": "embedAttributes.nn.decompounded",
      "matches": [
        "Publikum på <em>fotballkamp</em> i England. Foto."
      ]
    },
    {
      "field": "embedAttributes.nb.decompounded",
      "matches": [
        "Publikum på <em>fotballkamp</em> i England. Foto."
      ]
    }
  ]
}

```