### PR TITLE
#2310: Return entire objects when group searching

### DIFF
--- a/src/main/scala/no/ndla/searchapi/model/api/GroupSearchResult.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/GroupSearchResult.scala
@@ -10,18 +10,15 @@ package no.ndla.searchapi.model.api
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 import scala.annotation.meta.field
 
+// format: off
 @ApiModel(description = "Search result for group search")
 case class GroupSearchResult(
     @(ApiModelProperty @field)(description = "The total number of resources matching this query") totalCount: Long,
-    @(ApiModelProperty @field)(description = "Type of resources in this object") resourceType: String,
-    @(ApiModelProperty @field)(description = "For which page results are shown from") page: Int,
+    @(ApiModelProperty @field)(description = "For which page results are shown from") page: Option[Int],
     @(ApiModelProperty @field)(description = "The number of results per page") pageSize: Int,
     @(ApiModelProperty @field)(description = "The chosen search language") language: String,
-    @(ApiModelProperty @field)(description = "The search results") results: Seq[GroupSummary])
-
-@ApiModel(description = "Search result for group search")
-case class GroupSummary(
-    @(ApiModelProperty @field)(description = "The unique id of this resource") id: Long,
-    @(ApiModelProperty @field)(description = "The title of the resource") title: Title,
-    @(ApiModelProperty @field)(description = "The url pointing to the resource") url: String,
-    @(ApiModelProperty @field)(description = "The taxonomy paths for the resource") paths: List[String])
+    @(ApiModelProperty @field)(description = "The search results") results: Seq[MultiSearchSummary],
+    @(ApiModelProperty @field)(description = "The suggestions for other searches") suggestions: Seq[MultiSearchSuggestion],
+    @(ApiModelProperty @field)(description = "Type of resources in this object") resourceType: String
+)
+// format: on

--- a/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
@@ -11,6 +11,7 @@ import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
 
+// format: off
 @ApiModel(description = "Information about search-results")
 case class MultiSearchResult(
     @(ApiModelProperty @field)(description = "The total number of resources matching this query") totalCount: Long,
@@ -18,5 +19,6 @@ case class MultiSearchResult(
     @(ApiModelProperty @field)(description = "The number of results per page") pageSize: Int,
     @(ApiModelProperty @field)(description = "The chosen search language") language: String,
     @(ApiModelProperty @field)(description = "The search results") results: Seq[MultiSearchSummary],
-    @(ApiModelProperty @field)(description = "The suggestions for other searches") suggestions: Seq[
-      MultiSearchSuggestion])
+    @(ApiModelProperty @field)(description = "The suggestions for other searches") suggestions: Seq[MultiSearchSuggestion]
+)
+// format: on

--- a/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/MultiSearchSummary.scala
@@ -31,6 +31,7 @@ case class MultiSearchSummary(
     @(ApiModelProperty @field)(description = "Status information of the resource") status: Option[Status],
     @(ApiModelProperty @field)(description = "Traits for the resource") traits: List[String],
     @(ApiModelProperty @field)(description = "Relevance score. The higher the score, the better the document matches your search criteria.") score: Float,
-    @(ApiModelProperty @field)(description = "List of objects describing matched field with matching words emphasized") highlights: List[HighlightedField]
+    @(ApiModelProperty @field)(description = "List of objects describing matched field with matching words emphasized") highlights: List[HighlightedField],
+    @(ApiModelProperty @field)(description = "The taxonomy paths for the resource") paths: List[String]
 )
 // format: on

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -447,6 +447,10 @@ trait SearchConverterService {
       }.toList
     }
 
+    private def getPathsFromContext(contexts: List[SearchableTaxonomyContext]) = {
+      contexts.map(_.path)
+    }
+
     def articleHitAsMultiSummary(hit: SearchHit, language: String): MultiSearchSummary = {
       implicit val formats: Formats = SearchableLanguageFormats.JSonFormats
       val searchableArticle = read[SearchableArticle](hit.sourceAsString)
@@ -486,7 +490,8 @@ trait SearchConverterService {
         status = None,
         traits = searchableArticle.traits,
         score = hit.score,
-        highlights = getHighlights(hit.highlight)
+        highlights = getHighlights(hit.highlight),
+        paths = getPathsFromContext(searchableArticle.contexts)
       )
     }
 
@@ -529,7 +534,8 @@ trait SearchConverterService {
         status = Some(api.Status(searchableDraft.draftStatus.current, searchableDraft.draftStatus.other)),
         traits = searchableDraft.traits,
         score = hit.score,
-        highlights = getHighlights(hit.highlight)
+        highlights = getHighlights(hit.highlight),
+        paths = getPathsFromContext(searchableDraft.contexts)
       )
     }
 
@@ -572,7 +578,8 @@ trait SearchConverterService {
         status = Some(api.Status(searchableLearningPath.status, Seq.empty)),
         traits = List.empty,
         score = hit.score,
-        highlights = getHighlights(hit.highlight)
+        highlights = getHighlights(hit.highlight),
+        paths = getPathsFromContext(searchableLearningPath.contexts)
       )
     }
 
@@ -994,6 +1001,17 @@ trait SearchConverterService {
         searchResult.language,
         searchResult.results,
         searchResult.suggestions
+      )
+
+    def toApiGroupMultiSearchResult(group: String, searchResult: domain.SearchResult): GroupSearchResult =
+      api.GroupSearchResult(
+        searchResult.totalCount,
+        searchResult.page,
+        searchResult.pageSize,
+        searchResult.language,
+        searchResult.results,
+        searchResult.suggestions,
+        group
       )
 
   }


### PR DESCRIPTION
Relates to NDLANO/Issues#2310

- Legger til paths på `MultiSearchSummary` for at gruppesøket skal være bakoverkompatibelt.
- Bruker `MultiSearchSummary` i gruppesøket også.