### PR TITLE
#2310: Includes 'context-types' as groups for group search and param for no resource-type

### DIFF
--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -137,7 +137,7 @@ trait SearchController {
     )
 
     private val includeMissingResourceTypeGroup = Param[Option[Boolean]](
-      "include-without-resource-types",
+      "missing-group",
       "Whether to include group without resource-types for group-search. Defaults to false.")
 
     private val grepCodes = Param[Option[Seq[String]]](

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -25,7 +25,7 @@ case class SearchSettings(
     learningResourceTypes: List[LearningResourceType.Value],
     supportedLanguages: List[String],
     relevanceIds: List[String],
-    contextIds: List[String],
     grepCodes: List[String],
-    shouldScroll: Boolean
+    shouldScroll: Boolean,
+    filterByNoResourceType: Boolean // If true, and resourceTypes is empty, results will have no resource-type or taxonomy context
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -147,7 +147,7 @@ trait MultiDraftSearchService {
 
       val taxonomyContextFilter = contextTypeFilter(settings.learningResourceTypes)
       val taxonomyFilterFilter = levelFilter(settings.taxonomyFilters)
-      val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes)
+      val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes, filterByNoResourceType = false)
       val taxonomySubjectFilter = subjectFilter(settings.subjects)
       val taxonomyTopicFilter = topicFilter(settings.topics)
       val taxonomyRelevanceFilter = relevanceFilter(settings.relevanceIds, settings.subjects, settings.taxonomyFilters)

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -131,10 +131,9 @@ trait MultiSearchService {
 
       val taxonomyContextTypeFilter = contextTypeFilter(settings.learningResourceTypes)
       val taxonomyFilterFilter = levelFilter(settings.taxonomyFilters)
-      val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes)
+      val taxonomyResourceTypesFilter = resourceTypeFilter(settings.resourceTypes, settings.filterByNoResourceType)
       val taxonomySubjectFilter = subjectFilter(settings.subjects)
       val taxonomyRelevanceFilter = relevanceFilter(settings.relevanceIds, settings.subjects, settings.taxonomyFilters)
-      val taxonomyResourceTypesContextFilter = resourceTypeFilter(settings.contextIds)
 
       val supportedLanguageFilter =
         if (settings.supportedLanguages.isEmpty) None
@@ -155,7 +154,6 @@ trait MultiSearchService {
         taxonomyContextTypeFilter,
         supportedLanguageFilter,
         taxonomyRelevanceFilter,
-        taxonomyResourceTypesContextFilter,
         grepCodesFilter
       ).flatten
     }

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1119,9 +1119,9 @@ object TestData {
     learningResourceTypes = List.empty,
     supportedLanguages = List.empty,
     relevanceIds = List.empty,
-    contextIds = List.empty,
     grepCodes = List.empty,
-    shouldScroll = false
+    shouldScroll = false,
+    filterByNoResourceType = false
   )
 
   val multiDraftSearchSettings = MultiDraftSearchSettings(

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -567,9 +567,9 @@ class MultiSearchServiceTest extends IntegrationSuite with TestEnvironment {
 
   test("That filtering on context-types works") {
     val Success(search) =
-      multiSearchService.matchingQuery(searchSettings.copy(contextIds = List("urn:resourcetype:academicArticle")))
+      multiSearchService.matchingQuery(searchSettings.copy(resourceTypes = List("urn:resourcetype:academicArticle")))
     val Success(search2) =
-      multiSearchService.matchingQuery(searchSettings.copy(contextIds = List("urn:resourcetype:movieAndClip")))
+      multiSearchService.matchingQuery(searchSettings.copy(resourceTypes = List("urn:resourcetype:movieAndClip")))
 
     search.totalCount should be(2)
     search.results.map(_.id) should be(Seq(2, 5))
@@ -619,6 +619,16 @@ class MultiSearchServiceTest extends IntegrationSuite with TestEnvironment {
 
     search2.totalCount should be(1)
     search2.results.map(_.id) should be(Seq(12))
+  }
+
+  test("That filterByNoResourceType works by filtering out every document that does not have resourceTypes") {
+    val Success(search1) = multiSearchService.matchingQuery(
+      searchSettings.copy(
+        filterByNoResourceType = true,
+        language = Language.AllLanguages,
+        sort = Sort.ByIdAsc
+      ))
+    search1.results.map(_.id).sorted should be(Seq(6, 9, 10, 11))
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {


### PR DESCRIPTION
Relates to NDLANO/Issues#2310

- Lager grupper for `context-types` i gruppesøket også (`standard`/`topic-article`/`learningpath`)
- Legger til en parameter for å ha med en gruppe uten resourceType.

`/search-api/v1/search/group/?resource-types=urn%3Aresourcetype%3AsubjectMaterial&include-without-resource-types=true&context-types=topic-article`
gir dette resultatet (med treff i `results` array'ene):
```
[
  {
    "totalCount": 8802,
    "page": 1,
    "pageSize": 10,
    "language": "all",
    "results": [ ... ],
    "suggestions": [],
    "resourceType": "urn:resourcetype:subjectMaterial"
  },
  {
    "totalCount": 2463,
    "page": 1,
    "pageSize": 10,
    "language": "all",
    "results": [ ... ],
    "suggestions": [],
    "resourceType": "topic-article"
  },
  {
    "totalCount": 4085,
    "page": 1,
    "pageSize": 10,
    "language": "all",
    "results": [ ... ],
    "suggestions": [],
    "resourceType": "missing"
  }
]

```