### PR TITLE
Adds building, using, and returning termsAggregations from paths

### DIFF
--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -168,6 +168,11 @@ trait SearchController {
          |UpdatedBy on article and user in editorial-notes are searched.""".stripMargin
     )
 
+    private val aggregatePaths = Param[Option[Seq[String]]](
+      "aggregate-paths",
+      "List of index-paths that should be term-aggregated and returned in result."
+    )
+
     private def asQueryParam[T: Manifest: NotNothing](param: Param[T]) =
       queryParam[T](param.paramName).description(param.description)
 
@@ -240,7 +245,8 @@ trait SearchController {
         relevanceIds = relevances,
         grepCodes = grepCodes,
         shouldScroll = false,
-        filterByNoResourceType = false
+        filterByNoResourceType = false,
+        aggregatePaths = List.empty
       )
 
       groupSearch(settings, includeMissingResourceTypeGroup)
@@ -353,6 +359,7 @@ trait SearchController {
       val anotherResourceTypes = paramAsListOfString(this.contextFilters.paramName)
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
+      val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
 
       SearchSettings(
         query = query,
@@ -371,7 +378,8 @@ trait SearchController {
         relevanceIds = relevances,
         grepCodes = grepCodes,
         shouldScroll = shouldScroll,
-        filterByNoResourceType = false
+        filterByNoResourceType = false,
+        aggregatePaths = aggregatePaths
       )
     }
 
@@ -396,6 +404,7 @@ trait SearchController {
       val userFilter = paramAsListOfString(this.userFilter.paramName)
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
+      val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
 
       MultiDraftSearchSettings(
         query = query,
@@ -418,7 +427,8 @@ trait SearchController {
         userFilter = userFilter,
         grepCodes = grepCodes,
         shouldScroll = shouldScroll,
-        searchDecompounded = false
+        searchDecompounded = false,
+        aggregatePaths = aggregatePaths
       )
     }
 

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -484,7 +484,8 @@ trait SearchController {
             asQueryParam(relevanceFilter),
             asQueryParam(contextFilters),
             asQueryParam(scrollId),
-            asQueryParam(grepCodes)
+            asQueryParam(grepCodes),
+            asQueryParam(aggregatePaths)
           )
           .responseMessages(response500))
     ) {
@@ -525,6 +526,7 @@ trait SearchController {
             asQueryParam(statusFilter),
             asQueryParam(userFilter),
             asQueryParam(grepCodes),
+            asQueryParam(aggregatePaths)
           )
           .authorizations("oauth2")
           .responseMessages(response500))

--- a/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/MultiSearchResult.scala
@@ -19,6 +19,7 @@ case class MultiSearchResult(
     @(ApiModelProperty @field)(description = "The number of results per page") pageSize: Int,
     @(ApiModelProperty @field)(description = "The chosen search language") language: String,
     @(ApiModelProperty @field)(description = "The search results") results: Seq[MultiSearchSummary],
-    @(ApiModelProperty @field)(description = "The suggestions for other searches") suggestions: Seq[MultiSearchSuggestion]
+    @(ApiModelProperty @field)(description = "The suggestions for other searches") suggestions: Seq[MultiSearchSuggestion],
+    @(ApiModelProperty @field)(description = "The aggregated fields if specified in query") aggregations: Seq[MultiSearchTermsAggregation]
 )
 // format: on

--- a/src/main/scala/no/ndla/searchapi/model/api/MultiSearchTermsAggregation.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/MultiSearchTermsAggregation.scala
@@ -1,0 +1,22 @@
+package no.ndla.searchapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+
+import scala.annotation.meta.field
+
+// format: off
+@ApiModel(description = "Search suggestion options for the terms in the query")
+case class TermValue(
+    @(ApiModelProperty @field)(description = "Value that appeared in result") value: String,
+    @(ApiModelProperty @field)(description = "Number of times the value appeared in result") count: Long
+)
+
+@ApiModel(description = "Search suggestion options for the terms in the query")
+case class MultiSearchTermsAggregation(
+    @(ApiModelProperty @field)(description = "The field the specific aggregation is matching") field: String,
+    @(ApiModelProperty @field)(description = "Number of documents with values that didn't appear in the aggregation. (Will only happen if there are more than 50 different values)") sumOtherDocCount: Int,
+    @(ApiModelProperty @field)(description = "The result is approximate, this gives an approximation of potential errors. (Specifics here: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts)")
+    docCountErrorUpperBound: Int,
+    @(ApiModelProperty @field)(description = "Values appearing in the field") values: Seq[TermValue]
+)
+// format: on

--- a/src/main/scala/no/ndla/searchapi/model/api/MultiSearchTermsAggregation.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/MultiSearchTermsAggregation.scala
@@ -5,13 +5,13 @@ import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 import scala.annotation.meta.field
 
 // format: off
-@ApiModel(description = "Search suggestion options for the terms in the query")
+@ApiModel(description = "Value that appears in the search aggregation")
 case class TermValue(
     @(ApiModelProperty @field)(description = "Value that appeared in result") value: String,
     @(ApiModelProperty @field)(description = "Number of times the value appeared in result") count: Long
 )
 
-@ApiModel(description = "Search suggestion options for the terms in the query")
+@ApiModel(description = "Information about search aggregation on `field`")
 case class MultiSearchTermsAggregation(
     @(ApiModelProperty @field)(description = "The field the specific aggregation is matching") field: String,
     @(ApiModelProperty @field)(description = "Number of documents with values that didn't appear in the aggregation. (Will only happen if there are more than 50 different values)") sumOtherDocCount: Int,

--- a/src/main/scala/no/ndla/searchapi/model/domain/SearchResult.scala
+++ b/src/main/scala/no/ndla/searchapi/model/domain/SearchResult.scala
@@ -14,4 +14,5 @@ case class SearchResult(totalCount: Long,
                         language: String,
                         results: Seq[MultiSearchSummary],
                         suggestions: Seq[MultiSearchSuggestion],
+                        aggregations: Seq[TermAggregation],
                         scrollId: Option[String] = None)

--- a/src/main/scala/no/ndla/searchapi/model/domain/TermAggregation.scala
+++ b/src/main/scala/no/ndla/searchapi/model/domain/TermAggregation.scala
@@ -1,0 +1,7 @@
+package no.ndla.searchapi.model.domain
+
+case class Bucket(value: String, count: Long)
+case class TermAggregation(field: Seq[String],
+                           sumOtherDocCount: Int,
+                           docCountErrorUpperBound: Int,
+                           buckets: Seq[Bucket])

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -32,5 +32,6 @@ case class MultiDraftSearchSettings(
     userFilter: List[String],
     grepCodes: List[String],
     shouldScroll: Boolean,
-    searchDecompounded: Boolean
+    searchDecompounded: Boolean,
+    aggregatePaths: List[String]
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -27,5 +27,6 @@ case class SearchSettings(
     relevanceIds: List[String],
     grepCodes: List[String],
     shouldScroll: Boolean,
-    filterByNoResourceType: Boolean // If true, and resourceTypes is empty, results will have no resource-type or taxonomy context
+    filterByNoResourceType: Boolean, // If true, and resourceTypes is empty, results will have no resource-type or taxonomy context
+    aggregatePaths: List[String]
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/FakeAgg.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/FakeAgg.scala
@@ -1,0 +1,97 @@
+/*
+ * Part of NDLA search-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.searchapi.service.search
+
+import com.sksamuel.elastic4s.searches.aggs.Aggregation
+import com.sksamuel.elastic4s.http.ElasticDsl._
+
+/**
+  * [[FakeAgg]] and inheriting classes are an abstraction to easier work with Elastic4s' Aggregations
+  * They are usually used by calling `convertToReal()` which returns the real Elasitc4s [[Aggregation]]
+  * And then passing them to an aggregating search.
+  */
+sealed trait FakeAgg {
+  val name: String
+  val subAggregations: Seq[FakeAgg]
+  def withSubs(subs: Seq[FakeAgg]): FakeAgg
+  def addSubAggs(agg: FakeAgg): FakeAgg = withSubs(subAggregations :+ agg)
+  def convertToReal(): Aggregation
+
+  /** Attempts to merge `toMerge` into `this` [[FakeAgg]].
+    * @return Some(FakeAgg) if merge was successful, None if not.
+    */
+  def merge(toMerge: FakeAgg): Option[FakeAgg] = {
+    if (toMerge.name == this.name && toMerge.getClass == this.getClass) {
+      val subIdx = toMerge.subAggregations.zipWithIndex
+
+      val (mergedLSubIdxes, mergedSubs) =
+        this.subAggregations.foldLeft(Seq.empty[Int], Seq.empty[FakeAgg])((acc, thisSub) => {
+          val (mergedIdxes, result) = acc
+
+          // Attempts to merge all sub-aggregations from `toMerge` and keeps track of the merged ids
+          val merged = subIdx
+            .filterNot(s => mergedIdxes.contains(s._2))
+            .view
+            .map { case (subToMerge, idx) => (thisSub.merge(subToMerge), idx) }
+            .collectFirst { case (Some(mergedAgg), idx) => (mergedAgg, idx) }
+
+          val newMergedLSubs = mergedIdxes ++ merged.map(_._2).toSeq
+          val mergedAggs = result :+ merged.map(_._1).getOrElse(thisSub)
+
+          newMergedLSubs -> mergedAggs
+        })
+
+      // All unmerged sub-aggregations gets appended to the regular sub-aggregations
+      val extras = subIdx.filterNot { case (_, idx) => mergedLSubIdxes.contains(idx) }.map(_._1)
+
+      Some(this.withSubs(mergedSubs ++ extras))
+    } else { None }
+  }
+}
+
+object FakeAgg {
+
+  /**
+    * Converts sequence of aggregations into one aggregation with subaggregations
+    * @example    `Seq(FakeNestedAgg("a"), FakeNestedAgg("b"), "FakeTermAgg("c"))` will become:
+    *             Some(
+    *               FakeNestedAgg("a", subAggregations = Seq(
+    *                 FakeNestedAgg("b", subAggregations = Seq(
+    *                   FakeTermAgg("c")
+    *                 ))
+    *               ))
+    *             )
+    */
+  def seqAggsToSubAggs(aggs: Seq[FakeAgg]): Option[FakeAgg] =
+    aggs.reverse.foldLeft(None: Option[FakeAgg])((acc, cur) => {
+      acc match {
+        case None => Some(cur)
+        case Some(subs) =>
+          val x = cur.addSubAggs(subs)
+          Some(x)
+      }
+    })
+}
+
+case class FakeTermAgg(name: String, subAggregations: Seq[FakeAgg] = Seq.empty, field: String = "") extends FakeAgg {
+  def field(path: String): FakeTermAgg = this.copy(field = path)
+
+  override def withSubs(subs: Seq[FakeAgg]): FakeAgg = this.copy(subAggregations = subs)
+  override def convertToReal(): Aggregation = {
+    val subs = this.subAggregations.map(_.convertToReal())
+    termsAggregation(this.name).field(this.field).subAggregations(subs).size(50)
+  }
+}
+
+case class FakeNestedAgg(name: String, path: String, subAggregations: Seq[FakeAgg] = Seq.empty) extends FakeAgg {
+  override def withSubs(subs: Seq[FakeAgg]): FakeAgg = this.copy(subAggregations = subs)
+  override def convertToReal(): Aggregation = {
+    val subs = this.subAggregations.map(_.convertToReal())
+    nestedAggregation(name, path).subAggregations(subs)
+  }
+}

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -52,7 +52,7 @@ trait SearchConverterService {
       parents.flatMap(parent => getParentTopicsAndPaths(parent, bundle, path :+ parent.id)) :+ (topic, path)
     }
 
-    def parseHtml(html: String) = {
+    private def parseHtml(html: String) = {
       val document = Jsoup.parseBodyFragment(html)
       document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
       document.body()

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -993,6 +993,19 @@ trait SearchConverterService {
       (resources, topics)
     }
 
+    def toApiMultiTermsAggregation(agg: domain.TermAggregation): api.MultiSearchTermsAggregation =
+      api.MultiSearchTermsAggregation(
+        field = agg.field.mkString("."),
+        sumOtherDocCount = agg.sumOtherDocCount,
+        docCountErrorUpperBound = agg.docCountErrorUpperBound,
+        values = agg.buckets.map(
+          b =>
+            api.TermValue(
+              value = b.value,
+              count = b.count
+          ))
+      )
+
     def toApiMultiSearchResult(searchResult: domain.SearchResult): MultiSearchResult =
       api.MultiSearchResult(
         searchResult.totalCount,
@@ -1000,7 +1013,8 @@ trait SearchConverterService {
         searchResult.pageSize,
         searchResult.language,
         searchResult.results,
-        searchResult.suggestions
+        searchResult.suggestions,
+        searchResult.aggregations.map(toApiMultiTermsAggregation)
       )
 
     def toApiGroupMultiSearchResult(group: String, searchResult: domain.SearchResult): GroupSearchResult =

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -190,7 +190,7 @@ trait SearchService {
         }
       }
 
-      _buildAggregationRecursive(path.split("\\."), path, fieldsInIndex, Seq.empty, Seq.empty).map(_._1)
+      _buildAggregationRecursive(path.split("\\.").toSeq, path, fieldsInIndex, Seq.empty, Seq.empty).map(_._1)
     }
 
     def getAggregationsFromResult(response: SearchResponse): Seq[TermAggregation] = {

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1121,7 +1121,8 @@ object TestData {
     relevanceIds = List.empty,
     grepCodes = List.empty,
     shouldScroll = false,
-    filterByNoResourceType = false
+    filterByNoResourceType = false,
+    aggregatePaths = List.empty
   )
 
   val multiDraftSearchSettings = MultiDraftSearchSettings(
@@ -1145,7 +1146,8 @@ object TestData {
     userFilter = List.empty,
     grepCodes = List.empty,
     shouldScroll = false,
-    searchDecompounded = false
+    searchDecompounded = false,
+    aggregatePaths = List.empty
   )
 
   val searchableResourceTypes = List(

--- a/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
+++ b/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
@@ -33,7 +33,8 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   }
 
   test("That / returns 200 ok") {
-    val multiResult = domain.SearchResult(0, Some(1), 10, "nb", Seq.empty, suggestions = Seq.empty)
+    val multiResult =
+      domain.SearchResult(0, Some(1), 10, "nb", Seq.empty, suggestions = Seq.empty, aggregations = Seq.empty)
     when(multiSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(multiResult))
     get("/test/") {
       status should equal(200)
@@ -41,7 +42,8 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   }
 
   test("That /group/ returns 200 ok") {
-    val multiResult = domain.SearchResult(0, Some(1), 10, "nb", Seq.empty, suggestions = Seq.empty)
+    val multiResult =
+      domain.SearchResult(0, Some(1), 10, "nb", Seq.empty, suggestions = Seq.empty, aggregations = Seq.empty)
     when(multiSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(multiResult))
     get("/test/group/?resource-types=test") {
       status should equal(200)
@@ -53,7 +55,7 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     val validScrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
 
-    val multiResult = domain.SearchResult(0, None, 10, "nb", Seq.empty, Seq.empty, Some(validScrollId))
+    val multiResult = domain.SearchResult(0, None, 10, "nb", Seq.empty, Seq.empty, Seq.empty, Some(validScrollId))
 
     when(multiSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(multiResult))
     get(s"/test/") {
@@ -69,7 +71,7 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     val validScrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
 
-    val multiResult = domain.SearchResult(0, None, 10, "nb", Seq.empty, Seq.empty, Some(validScrollId))
+    val multiResult = domain.SearchResult(0, None, 10, "nb", Seq.empty, Seq.empty, Seq.empty, Some(validScrollId))
 
     when(multiDraftSearchService.matchingQuery(any[MultiDraftSearchSettings])).thenReturn(Success(multiResult))
     when(user.getUser).thenReturn(UserInfo("SomeId", Set(Role.DRAFTWRITE)))
@@ -88,7 +90,7 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     val newValidScrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAtAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
 
-    val multiResult = domain.SearchResult(0, None, 10, "nn", Seq.empty, Seq.empty, Some(newValidScrollId))
+    val multiResult = domain.SearchResult(0, None, 10, "nn", Seq.empty, Seq.empty, Seq.empty, Some(newValidScrollId))
 
     when(multiSearchService.scroll(eqTo(validScrollId), eqTo("nn"), eqTo(true))).thenReturn(Success(multiResult))
     get(s"/test/?search-context=$validScrollId&language=nn&fallback=true") {
@@ -106,7 +108,7 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     val newValidScrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAtAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
 
-    val multiResult = domain.SearchResult(0, None, 10, "nn", Seq.empty, Seq.empty, Some(newValidScrollId))
+    val multiResult = domain.SearchResult(0, None, 10, "nn", Seq.empty, Seq.empty, Seq.empty, Some(newValidScrollId))
 
     when(multiDraftSearchService.scroll(eqTo(validScrollId), eqTo("nn"), eqTo(true))).thenReturn(Success(multiResult))
     when(user.getUser).thenReturn(UserInfo("SomeId", Set(Role.DRAFTWRITE)))

--- a/src/test/scala/no/ndla/searchapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/SearchServiceTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Part of NDLA search-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.searchapi.service.search
+
+import no.ndla.searchapi.{TestEnvironment, UnitSuite}
+import com.sksamuel.elastic4s.http.ElasticDsl._
+import no.ndla.searchapi.SearchApiProperties.SearchIndexes
+import no.ndla.searchapi.model.search.SearchType
+
+class SearchServiceTest extends UnitSuite with TestEnvironment {
+  override val draftIndexService = new DraftIndexService
+  override val learningPathIndexService = new LearningPathIndexService
+
+  val service: SearchService = new SearchService {
+    override val searchIndex = List(SearchIndexes(SearchType.Drafts), SearchIndexes(SearchType.LearningPaths))
+    override val indexServices: List[IndexService[_]] = List(draftIndexService, learningPathIndexService)
+    override protected def scheduleIndexDocuments(): Unit = {}
+  }
+
+  test("That building single termsAggregation works as expected") {
+    val res1 = service.buildTermsAggregation(Seq("draftStatus.current"))
+    res1 should be(
+      Seq(
+        termsAggregation("draftStatus.current")
+          .field("draftStatus.current")
+          .size(50)
+      ))
+  }
+
+  test("That building nested termsAggregation works as expected") {
+    val res1 = service.buildTermsAggregation(Seq("contexts.contextType"))
+    res1 should be(
+      Seq(
+        nestedAggregation("contexts", "contexts").subAggregations(
+          termsAggregation("contextType").field("contexts.contextType").size(50)
+        )))
+  }
+
+  test("That building nested multiple layers termsAggregation works as expected") {
+    val res1 = service.buildTermsAggregation(Seq("contexts.resourceTypes.id"))
+    res1 should be(
+      Seq(
+        nestedAggregation("contexts", "contexts")
+          .subAggregations(
+            nestedAggregation("resourceTypes", "contexts.resourceTypes")
+              .subAggregations(
+                termsAggregation("id").field("contexts.resourceTypes.id").size(50)
+              )
+          )
+      )
+    )
+  }
+
+  test("That aggregating paths that requires merging works as expected") {
+    val res1 = service.buildTermsAggregation(Seq("contexts.contextType", "contexts.resourceTypes.id"))
+
+    res1 should be(
+      Seq(
+        nestedAggregation("contexts", "contexts")
+          .subAggregations(
+            nestedAggregation("resourceTypes", "contexts.resourceTypes")
+              .subAggregations(
+                termsAggregation("id").field("contexts.resourceTypes.id").size(50)
+              ),
+            termsAggregation("contextType").field("contexts.contextType").size(50),
+          )
+      ))
+  }
+
+  test("That building multiple termsAggregation works as expected") {
+    val res1 = service.buildTermsAggregation(
+      Seq("draftStatus.current", "draftStatus.other", "contexts.contextType", "contexts.resourceTypes.id")
+    )
+    res1 should be(
+      Seq(
+        termsAggregation("draftStatus.current").field("draftStatus.current").size(50),
+        termsAggregation("draftStatus.other").field("draftStatus.other").size(50),
+        nestedAggregation("contexts", "contexts")
+          .subAggregations(
+            nestedAggregation("resourceTypes", "contexts.resourceTypes")
+              .subAggregations(
+                termsAggregation("id").field("contexts.resourceTypes.id").size(50)
+              ),
+            termsAggregation("contextType").field("contexts.contextType").size(50),
+          )
+      ))
+  }
+
+  test("that passing in an empty list does not crash even though it shouldnt happen") {
+    val res1 = service.buildTermsAggregation(Seq.empty)
+    res1 should be(Seq.empty)
+  }
+
+  def blockUntil(predicate: () => Boolean): Unit = {
+    var backoff = 0
+    var done = false
+
+    while (backoff <= 16 && !done) {
+      if (backoff > 0) Thread.sleep(200 * backoff)
+      backoff = backoff + 1
+      try {
+        done = predicate()
+      } catch {
+        case e: Throwable => println("problem while testing predicate", e)
+      }
+    }
+
+    require(done, s"Failed waiting for predicate")
+  }
+}


### PR DESCRIPTION
Relates to NDLANO/Issues#2125

Legger til query-param `aggregate-paths` som tar in en path i indeksen som aggregeres og vises i søke-resultatet
Feks:

GET `/search-api/v1/search/editorial/?aggregate-paths=contexts.contextType`
```
{
  "totalCount": 23329,
  "page": 1,
  "pageSize": 10,
  "language": "all",
  "results": [
    ... // Vanlige resultater
  ],
  "suggestions": [],
  "aggregations": [
    {
      "field": "contexts.contextType",
      "sumOtherDocCount": 0,
      "docCountErrorUpperBound": 0,
      "values": [
        {
          "value": "standard",
          "count": 27589
        },
        {
          "value": "topic-article",
          "count": 2620
        },
        {
          "value": "learningpath",
          "count": 1288
        }
      ]
    }
  ]
}
```

Koden er litt små-kompleks så om dere finner noe som ikke er kommentert som er vanskelig å lese, så sleng en kommentar så skal jeg prøve så godt jeg kan å forklare den (og kommentere den).
