### PR TITLE
Login to ECR repo on travis to not cancel tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,19 @@ matrix:
         - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
         - find $HOME/.sbt -name "*.lock" -delete
       before_script:
-        - echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
+        # Install awscli
+        - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        - unzip awscliv2.zip
+        - sudo ./aws/install
 
+        # Use awscli to login to ECR repo
+        - RES=$(aws sts assume-role --role-arn arn:aws:iam::950645517739:role/releaseAccess --role-session-name travis-test-release-pull-whatever)
+        - AWS_ACCESS_KEY_ID=$(echo $RES | jq -r .Credentials.AccessKeyId)
+          AWS_SECRET_ACCESS_KEY=$(echo $RES | jq -r .Credentials.SecretAccessKey)
+          AWS_SESSION_TOKEN=$(echo $RES | jq -r .Credentials.SessionToken) 
+          aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 950645517739.dkr.ecr.eu-central-1.amazonaws.com
+
+        - echo $DOCKER_HUB_PASSWORD | docker login --username $DOCKER_HUB_USERNAME --password-stdin
     - name: "Release"
       language: python
       if: branch = master AND type = push

--- a/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
@@ -16,7 +16,7 @@ import no.ndla.searchapi.{TestData, TestEnvironment, UnitSuite}
 import org.json4s.native.Serialization.read
 import org.scalatest.Outcome
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 class ArticleIndexServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
@@ -26,6 +26,14 @@ class ArticleIndexServiceTest
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
   // Skip tests if no docker environment available
   override def withFixture(test: NoArgTest): Outcome = {
+    elasticSearchContainer match {
+      case Failure(ex) =>
+        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
+        println(s"Got exception: ${ex.getMessage}")
+        ex.printStackTrace()
+      case _ =>
+    }
+
     assume(elasticSearchContainer.isSuccess)
     super.withFixture(test)
   }

--- a/src/test/scala/no/ndla/searchapi/service/search/IndexServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/IndexServiceTest.scala
@@ -13,12 +13,20 @@ import no.ndla.searchapi.integration.Elastic4sClientFactory
 import no.ndla.searchapi.TestEnvironment
 import org.scalatest.Outcome
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 class IndexServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
   // Skip tests if no docker environment available
   override def withFixture(test: NoArgTest): Outcome = {
+    elasticSearchContainer match {
+      case Failure(ex) =>
+        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
+        println(s"Got exception: ${ex.getMessage}")
+        ex.printStackTrace()
+      case _ =>
+    }
+
     assume(elasticSearchContainer.isSuccess)
     super.withFixture(test)
   }

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -8,7 +8,6 @@
 package no.ndla.searchapi.service.search
 
 import java.nio.file.{Files, Path}
-
 import no.ndla.scalatestsuite.IntegrationSuite
 import no.ndla.searchapi.SearchApiProperties.DefaultPageSize
 import no.ndla.searchapi.TestData._
@@ -21,12 +20,20 @@ import no.ndla.searchapi.model.search.SearchType
 import no.ndla.searchapi.{SearchApiProperties, TestEnvironment, UnitSuite}
 import org.scalatest.Outcome
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchContainer = true) with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
   // Skip tests if no docker environment available
   override def withFixture(test: NoArgTest): Outcome = {
+    elasticSearchContainer match {
+      case Failure(ex) =>
+        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
+        println(s"Got exception: ${ex.getMessage}")
+        ex.printStackTrace()
+      case _ =>
+    }
+
     assume(elasticSearchContainer.isSuccess)
     super.withFixture(test)
   }

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -19,15 +19,24 @@ import no.ndla.searchapi.model.search.SearchType
 import no.ndla.searchapi.{SearchApiProperties, TestData, TestEnvironment, UnitSuite}
 import org.scalatest.Outcome
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 class MultiSearchServiceTest
     extends IntegrationSuite(EnableElasticsearchContainer = true)
     with UnitSuite
     with TestEnvironment {
   e4sClient = Elastic4sClientFactory.getClient(elasticSearchHost.getOrElse(""))
+
   // Skip tests if no docker environment available
   override def withFixture(test: NoArgTest): Outcome = {
+    elasticSearchContainer match {
+      case Failure(ex) =>
+        println(s"Elasticsearch container not running, cancelling '${this.getClass.getName}'")
+        println(s"Got exception: ${ex.getMessage}")
+        ex.printStackTrace()
+      case _ =>
+    }
+
     assume(elasticSearchContainer.isSuccess)
     super.withFixture(test)
   }


### PR DESCRIPTION
Installerer awscli og bruker den for å logge inn i ECR-repoet for å få tilgang til search-engine imaget som brukes i testene.