### PR TITLE
2403 2425 add indexing and search on more embed attributes

### DIFF
--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -173,6 +173,11 @@ trait SearchController {
       "List of index-paths that should be term-aggregated and returned in result."
     )
 
+    private val embedResource = Param[Option[String]]("embedResource", "Return only results with embed resource matching the specified resource.")
+
+    private val embedId = Param[Option[String]]("embedId", "Return only results with embed attribute matching the specified id.")
+
+
     private def asQueryParam[T: Manifest: NotNothing](param: Param[T]) =
       queryParam[T](param.paramName).description(param.description)
 
@@ -226,7 +231,9 @@ trait SearchController {
       val anotherResourceTypes = paramAsListOfString(this.contextFilters.paramName)
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val includeMissingResourceTypeGroup =
-        booleanOrDefault(this.includeMissingResourceTypeGroup.paramName, default = false)
+      booleanOrDefault(this.includeMissingResourceTypeGroup.paramName, default = false)
+      val embedResource = paramOrNone(this.embedResource.paramName)
+      val embedId = paramOrNone(this.embedId.paramName)
 
       val settings = SearchSettings(
         query = query,
@@ -246,7 +253,9 @@ trait SearchController {
         grepCodes = grepCodes,
         shouldScroll = false,
         filterByNoResourceType = false,
-        aggregatePaths = List.empty
+        aggregatePaths = List.empty,
+        embedResource = embedResource,
+        embedId = embedId
       )
 
       groupSearch(settings, includeMissingResourceTypeGroup)
@@ -320,7 +329,9 @@ trait SearchController {
             asQueryParam(pageNo),
             asQueryParam(pageSize),
             asQueryParam(apiTypes),
-            asQueryParam(sort)
+            asQueryParam(sort),
+            asQueryParam(embedResource),
+            asQueryParam(embedId)
           )
           .responseMessages(response500))
     ) {
@@ -360,6 +371,8 @@ trait SearchController {
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
+      val embedResource = paramOrNone(this.embedResource.paramName)
+      val embedId = paramOrNone(this.embedId.paramName)
 
       SearchSettings(
         query = query,
@@ -379,7 +392,9 @@ trait SearchController {
         grepCodes = grepCodes,
         shouldScroll = shouldScroll,
         filterByNoResourceType = false,
-        aggregatePaths = aggregatePaths
+        aggregatePaths = aggregatePaths,
+        embedResource = embedResource,
+        embedId = embedId
       )
     }
 
@@ -405,6 +420,8 @@ trait SearchController {
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
+      val embedResource = paramOrNone(this.embedResource.paramName)
+      val embedId = paramOrNone(this.embedId.paramName)
 
       MultiDraftSearchSettings(
         query = query,
@@ -428,7 +445,9 @@ trait SearchController {
         grepCodes = grepCodes,
         shouldScroll = shouldScroll,
         searchDecompounded = false,
-        aggregatePaths = aggregatePaths
+        aggregatePaths = aggregatePaths,
+        embedResource = embedResource,
+        embedId = embedId
       )
     }
 

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -174,10 +174,12 @@ trait SearchController {
     )
 
     private val embedResource =
-      Param[Option[String]]("embedResource", "Return only results with embed resource matching the specified resource.")
+      Param[Option[String]]("embedResource", "Return only results with embed data-resource the specified resource.")
 
     private val embedId =
-      Param[Option[String]]("embedId", "Return only results with embed attribute matching the specified id.")
+      Param[Option[String]](
+        "embedId",
+        "Return only results with embed data-resource_id, data-videoid or data-url with the specified id.")
 
     private def asQueryParam[T: Manifest: NotNothing](param: Param[T]) =
       queryParam[T](param.paramName).description(param.description)

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -173,10 +173,11 @@ trait SearchController {
       "List of index-paths that should be term-aggregated and returned in result."
     )
 
-    private val embedResource = Param[Option[String]]("embedResource", "Return only results with embed resource matching the specified resource.")
+    private val embedResource =
+      Param[Option[String]]("embedResource", "Return only results with embed resource matching the specified resource.")
 
-    private val embedId = Param[Option[String]]("embedId", "Return only results with embed attribute matching the specified id.")
-
+    private val embedId =
+      Param[Option[String]]("embedId", "Return only results with embed attribute matching the specified id.")
 
     private def asQueryParam[T: Manifest: NotNothing](param: Param[T]) =
       queryParam[T](param.paramName).description(param.description)
@@ -231,7 +232,7 @@ trait SearchController {
       val anotherResourceTypes = paramAsListOfString(this.contextFilters.paramName)
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val includeMissingResourceTypeGroup =
-      booleanOrDefault(this.includeMissingResourceTypeGroup.paramName, default = false)
+        booleanOrDefault(this.includeMissingResourceTypeGroup.paramName, default = false)
       val embedResource = paramOrNone(this.embedResource.paramName)
       val embedId = paramOrNone(this.embedId.paramName)
 

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -174,11 +174,11 @@ trait SearchController {
     )
 
     private val embedResource =
-      Param[Option[String]]("embedResource", "Return only results with embed data-resource the specified resource.")
+      Param[Option[String]]("embed-resource", "Return only results with embed data-resource the specified resource.")
 
     private val embedId =
       Param[Option[String]](
-        "embedId",
+        "embed-id",
         "Return only results with embed data-resource_id, data-videoid or data-url with the specified id.")
 
     private def asQueryParam[T: Manifest: NotNothing](param: Param[T]) =

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
@@ -28,5 +28,7 @@ case class SearchableArticle(
     contexts: List[SearchableTaxonomyContext],
     grepContexts: List[SearchableGrepContext],
     traits: List[String],
-    embedAttributes: SearchableLanguageList
+    embedAttributes: SearchableLanguageList,
+    embedResources: List[String],
+    embedIds: List[String]
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
@@ -32,5 +32,7 @@ case class SearchableDraft(
     previousVersionsNotes: List[String],
     grepContexts: List[SearchableGrepContext],
     traits: List[String],
-    embedAttributes: SearchableLanguageList
+    embedAttributes: SearchableLanguageList,
+    embedResources: List[String],
+    embedIds: List[String]
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -33,5 +33,7 @@ case class MultiDraftSearchSettings(
     grepCodes: List[String],
     shouldScroll: Boolean,
     searchDecompounded: Boolean,
-    aggregatePaths: List[String]
+    aggregatePaths: List[String],
+    embedResource: Option[String],
+    embedId: Option[String]
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -28,5 +28,7 @@ case class SearchSettings(
     grepCodes: List[String],
     shouldScroll: Boolean,
     filterByNoResourceType: Boolean, // If true, and resourceTypes is empty, results will have no resource-type or taxonomy context
-    aggregatePaths: List[String]
+    aggregatePaths: List[String],
+    embedResource: Option[String],
+    embedId: Option[String]
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -62,7 +62,9 @@ trait ArticleIndexService {
             keywordField("imageId"),
             keywordField("altText"),
             keywordField("language")
-          )
+          ),
+          keywordField("embedResources"),
+          keywordField("embedIds")
         )
           ++
             generateLanguageSupportedFieldList("title", keepRaw = true) ++

--- a/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -68,7 +68,9 @@ trait DraftIndexService {
             keywordField("imageId"),
             keywordField("altText"),
             keywordField("language")
-          )
+          ),
+          keywordField("embedResources"),
+          keywordField("embedIds")
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("metaDescription") ++

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -8,8 +8,7 @@
 package no.ndla.searchapi.service.search
 
 import java.util.concurrent.Executors
-
-import com.sksamuel.elastic4s.http.ElasticDsl._
+import com.sksamuel.elastic4s.http.ElasticDsl.{simpleStringQuery, _}
 import com.sksamuel.elastic4s.searches.queries.{BoolQuery, Query}
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.searchapi.SearchApiProperties
@@ -64,7 +63,9 @@ trait MultiDraftSearchService {
           simpleStringQuery(queryString).field("authors", 1),
           simpleStringQuery(queryString).field("notes", 1),
           simpleStringQuery(queryString).field("previousVersionsNotes", 1),
-          simpleStringQuery(queryString).field("grepContexts.title", 1)
+          simpleStringQuery(queryString).field("grepContexts.title", 1),
+          simpleStringQuery(queryString).field("embedResources", 3),
+          simpleStringQuery(queryString).field("embedIds", 3),
         )
 
       })
@@ -90,7 +91,6 @@ trait MultiDraftSearchService {
             simpleStringQuery(q).field("embedIds", 1),
           )
       })
-
 
       val boolQueries: List[BoolQuery] = List(contentSearch, noteSearch, embedResourceSearch, embedIdSearch).flatten
       val fullQuery = boolQuery().must(boolQueries)

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -64,8 +64,8 @@ trait MultiDraftSearchService {
           simpleStringQuery(queryString).field("notes", 1),
           simpleStringQuery(queryString).field("previousVersionsNotes", 1),
           simpleStringQuery(queryString).field("grepContexts.title", 1),
-          simpleStringQuery(queryString).field("embedResources", 3),
-          simpleStringQuery(queryString).field("embedIds", 3),
+          simpleStringQuery(queryString).field("embedResources", 1),
+          simpleStringQuery(queryString).field("embedIds", 1),
           idsQuery(queryString)
         )
 
@@ -82,14 +82,14 @@ trait MultiDraftSearchService {
       val embedResourceSearch = settings.embedResource.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedResources", 3),
+            simpleStringQuery(q).field("embedResources", 1),
           )
       })
 
       val embedIdSearch = settings.embedId.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedIds", 3),
+            simpleStringQuery(q).field("embedIds", 1),
           )
       })
 

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -77,7 +77,22 @@ trait MultiDraftSearchService {
           )
       })
 
-      val boolQueries: List[BoolQuery] = List(contentSearch, noteSearch).flatten
+      val embedResourceSearch = settings.embedResource.map(q => {
+        boolQuery()
+          .should(
+            simpleStringQuery(q).field("embedResources", 1),
+          )
+      })
+
+      val embedIdSearch = settings.embedId.map(q => {
+        boolQuery()
+          .should(
+            simpleStringQuery(q).field("embedIds", 1),
+          )
+      })
+
+
+      val boolQueries: List[BoolQuery] = List(contentSearch, noteSearch, embedResourceSearch, embedIdSearch).flatten
       val fullQuery = boolQuery().must(boolQueries)
 
       executeSearch(settings, fullQuery)

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -66,6 +66,7 @@ trait MultiDraftSearchService {
           simpleStringQuery(queryString).field("grepContexts.title", 1),
           simpleStringQuery(queryString).field("embedResources", 3),
           simpleStringQuery(queryString).field("embedIds", 3),
+          idsQuery(queryString)
         )
 
       })

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -82,14 +82,14 @@ trait MultiDraftSearchService {
       val embedResourceSearch = settings.embedResource.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedResources", 1),
+            simpleStringQuery(q).field("embedResources", 3),
           )
       })
 
       val embedIdSearch = settings.embedId.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedIds", 1),
+            simpleStringQuery(q).field("embedIds", 3),
           )
       })
 

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -64,6 +64,7 @@ trait MultiSearchService {
             simpleStringQuery(queryString).field("grepContexts.title", 1),
             simpleStringQuery(queryString).field("embedResources", 3),
             simpleStringQuery(queryString).field("embedIds", 3),
+            idsQuery(queryString)
           ))
       })
 

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -71,14 +71,14 @@ trait MultiSearchService {
       val embedResourceSearch = settings.embedResource.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedResources", 1),
+            simpleStringQuery(q).field("embedResources", 3),
           )
       })
 
       val embedIdSearch = settings.embedId.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedIds", 1),
+            simpleStringQuery(q).field("embedIds", 3),
           )
       })
 

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -62,8 +62,8 @@ trait MultiSearchService {
             langQueryFunc("embedAttributes", 1),
             simpleStringQuery(queryString).field("authors", 1),
             simpleStringQuery(queryString).field("grepContexts.title", 1),
-            simpleStringQuery(queryString).field("embedResources", 3),
-            simpleStringQuery(queryString).field("embedIds", 3),
+            simpleStringQuery(queryString).field("embedResources", 1),
+            simpleStringQuery(queryString).field("embedIds", 1),
             idsQuery(queryString)
           ))
       })
@@ -71,14 +71,14 @@ trait MultiSearchService {
       val embedResourceSearch = settings.embedResource.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedResources", 3),
+            simpleStringQuery(q).field("embedResources", 1),
           )
       })
 
       val embedIdSearch = settings.embedId.map(q => {
         boolQuery()
           .should(
-            simpleStringQuery(q).field("embedIds", 3),
+            simpleStringQuery(q).field("embedIds", 1),
           )
       })
 

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -125,7 +125,7 @@ trait SearchConverterService {
         embed.attr(attr) match {
           case "" => None
           case a  => Some(a)
-        })
+      })
     }
 
     private[service] def getEmbedIds(html: String): List[String] = {
@@ -147,7 +147,7 @@ trait SearchConverterService {
         embed.attr(attr) match {
           case "" => None
           case a  => Some(a)
-        })
+      })
     }
 
     private def getAttributesToIndex(content: Seq[ArticleContent],

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1122,7 +1122,9 @@ object TestData {
     grepCodes = List.empty,
     shouldScroll = false,
     filterByNoResourceType = false,
-    aggregatePaths = List.empty
+    aggregatePaths = List.empty,
+    embedResource = None,
+    embedId = None
   )
 
   val multiDraftSearchSettings = MultiDraftSearchSettings(
@@ -1147,7 +1149,9 @@ object TestData {
     grepCodes = List.empty,
     shouldScroll = false,
     searchDecompounded = false,
-    aggregatePaths = List.empty
+    aggregatePaths = List.empty,
+    embedResource = None,
+    embedId = None
   )
 
   val searchableResourceTypes = List(

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -364,8 +364,10 @@ object TestData {
     id = Option(12),
     title = List(Title("Ekstrastoff", "nb")),
     content = List(
-      ArticleContent("Helsesøster H5P <embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\">",
-                     "nb")),
+      ArticleContent(
+        "Helsesøster H5P <embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test\" />",
+        "nb"
+      )),
     tags = List(Tag(List(""), "nb")),
     visualElement = List.empty,
     introduction = List(ArticleIntroduction("Ekstra", "nb")),
@@ -655,8 +657,11 @@ object TestData {
     title = List(Title("Ekstrastoff", "nb")),
     introduction = List(ArticleIntroduction("Ekstra", "nb")),
     metaDescription = List(MetaDescription("", "nb")),
-    content =
-      List(ArticleContent("<embed data-resource=\"concept\" data-resource_id=\"55\" data-title=\"Flubber\" />", "nb")),
+    content = List(
+      ArticleContent(
+        "<section><embed data-resource=\"concept\" data-resource_id=\"55\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test\" />",
+        "nb"
+      )),
     visualElement = List.empty,
     tags = List(Tag(List(""), "nb")),
     created = today.minusDays(10),

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -53,6 +53,10 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
         LanguageValue("en", Seq("One english"))
       ))
 
+    val embedResources = List("test resource 1", "test resource 2")
+
+    val embedIds = List("test id 1", "test id 2")
+
     val metaImages = List(ArticleMetaImage("1", "alt", "nb"))
 
     val original = SearchableArticle(
@@ -74,7 +78,9 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       grepContexts =
         List(SearchableGrepContext("K123", Some("some title")), SearchableGrepContext("K456", Some("some title 2"))),
       traits = List.empty,
-      embedAttributes = embedAttrs
+      embedAttributes = embedAttrs,
+      embedResources = embedResources,
+      embedIds = embedIds
     )
     val json = write(original)
     val deserialized = read[SearchableArticle](json)
@@ -119,6 +125,10 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
         LanguageValue("en", Seq("One english"))
       ))
 
+    val embedResources = List("test resource 1", "test resource 2")
+
+    val embedIds = List("test id 1", "test id 2")
+
     val metaImages = List(ArticleMetaImage("1", "alt", "nb"))
     val filterWithNullName =
       SearchableTaxonomyFilter(
@@ -147,7 +157,9 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       grepContexts =
         List(SearchableGrepContext("K123", Some("some title")), SearchableGrepContext("K456", Some("some title 2"))),
       traits = List.empty,
-      embedAttributes = embedAttrs
+      embedAttributes = embedAttrs,
+      embedResources = embedResources,
+      embedIds = embedIds
     )
 
     val json = write(original)

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -54,6 +54,10 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
         LanguageValue("en", Seq("One english"))
       ))
 
+    val embedResources = List("test resource 1", "test resource 2")
+
+    val embedIds = List("test id 1", "test id 2")
+
     val original = SearchableDraft(
       id = 100,
       draftStatus = Status(ArticleStatus.DRAFT.toString, Seq(ArticleStatus.PROPOSAL.toString)),
@@ -77,7 +81,9 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
       grepContexts =
         List(SearchableGrepContext("K123", Some("some title")), SearchableGrepContext("K456", Some("some title 2"))),
       traits = List.empty,
-      embedAttributes = embedAttrs
+      embedAttributes = embedAttrs,
+      embedResources = embedResources,
+      embedIds = embedIds
     )
     val json = write(original)
     val deserialized = read[SearchableDraft](json)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -787,9 +787,84 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     search.results.map(_.id) should be(Seq(12))
   }
 
-  test("That search on embed data attribute only returns articles with exact attribute") {
+  test("That search on embed data attribute does not return article with partial match") {
     val Success(results) =
-      multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedResource = Some("concept")))
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(embedResource = Some("conc"), embedId = Some("55")))
+    results.totalCount should be(0)
+  }
+
+  test("That search on embed data-resource_id does return article with exact match") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedId = Some("66")))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search on embed dataId and resource can be combined with other parameters") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("Ekstra"),
+          embedResource = Some("concept"),
+          embedId = Some("55")
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search will return none on embed data id and resource search if other params doesnt match") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+          embedResource = Some("concept"),
+          embedId = Some("77")
+        ))
+    results.totalCount should be(0)
+  }
+
+  test("That search on embed data-resource works") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          embedResource = Some("video"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search on embed data-url works") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          embedId = Some("http://test"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search matches embed data ids exact on query parameter") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("77"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search matches embed data resource exact on query parameter") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("video"),
+        ))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -787,6 +787,14 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     search.results.map(_.id) should be(Seq(12))
   }
 
+  test("That search on embed data attribute only returns articles with exact attribute") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedResource = Some("concept")))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -787,14 +787,14 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     search.results.map(_.id) should be(Seq(12))
   }
 
-  test("That search on embed data attribute does not return article with partial match") {
+  test("That searches for embedResource does not partial match") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(embedResource = Some("conc"), embedId = Some("55")))
     results.totalCount should be(0)
   }
 
-  test("That search on embed data-resource_id does return article with exact match") {
+  test("That searches for data-resource_id matches") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedId = Some("66")))
     val hits = results.results
@@ -802,7 +802,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.head.id should be(12)
   }
 
-  test("That search on embed dataId and resource can be combined with other parameters") {
+  test("That searches on embedId and embedResource matches when using other parameters") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
@@ -815,7 +815,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.head.id should be(12)
   }
 
-  test("That search will return none on embed data id and resource search if other params doesnt match") {
+  test("That searches on embedResource and embedId doesn't match when other parameters have no hits") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
@@ -826,7 +826,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     results.totalCount should be(0)
   }
 
-  test("That search on embed data-resource works") {
+  test("That search on embed data-resource matches") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
@@ -837,7 +837,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.head.id should be(12)
   }
 
-  test("That search on embed data-url works") {
+  test("That search on embed data-url matches") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
@@ -848,7 +848,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.head.id should be(12)
   }
 
-  test("That search matches embed data ids exact on query parameter") {
+  test("That search on query as embed data-resource_id matches") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
@@ -859,7 +859,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.head.id should be(12)
   }
 
-  test("That search matches embed data resource exact on query parameter") {
+  test("That search on query as embed data-resouce matches") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
@@ -868,6 +868,17 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)
+  }
+
+  test("That search on query as article id matches") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("11"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(11)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -640,9 +640,83 @@ class MultiSearchServiceTest
     search1.totalCount should be(0)
   }
 
-  test("That search on embed data attribute only returns articles with exact attribute") {
+  test("That search on embed data attribute does not return article with partial match") {
     val Success(results) =
-      multiSearchService.matchingQuery(searchSettings.copy(embedResource = Some("h5p")))
+      multiSearchService.matchingQuery(searchSettings.copy(embedResource = Some("conc"), embedId = Some("55")))
+    results.totalCount should be(0)
+  }
+
+  test("That search on embed data-resource_id does return article with exact match") {
+    val Success(results) =
+      multiSearchService.matchingQuery(searchSettings.copy(embedId = Some("66")))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search on embed dataId and resource can be combined with other parameters") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("Ekstra"),
+          embedResource = Some("video"),
+          embedId = Some("77")
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search will return none on embed data id and resource search if other params doesnt match") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+          embedResource = Some("video"),
+          embedId = Some("77")
+        ))
+    results.totalCount should be(0)
+  }
+
+  test("That search on embed data-resource works") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          embedResource = Some("video"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search on embed data-url works") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          embedId = Some("http://test"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search matches embed data ids exact on query parameter") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("77"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search matches embed data resource exact on query parameter") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("video"),
+        ))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -640,13 +640,13 @@ class MultiSearchServiceTest
     search1.totalCount should be(0)
   }
 
-  test("That search on embed data attribute does not return article with partial match") {
+  test("That searches for embedResource does not partial match") {
     val Success(results) =
-      multiSearchService.matchingQuery(searchSettings.copy(embedResource = Some("conc"), embedId = Some("55")))
+      multiSearchService.matchingQuery(searchSettings.copy(embedResource = Some("vid"), embedId = Some("55")))
     results.totalCount should be(0)
   }
 
-  test("That search on embed data-resource_id does return article with exact match") {
+  test("That searches for data-resource_id matches") {
     val Success(results) =
       multiSearchService.matchingQuery(searchSettings.copy(embedId = Some("66")))
     val hits = results.results
@@ -654,7 +654,7 @@ class MultiSearchServiceTest
     hits.head.id should be(12)
   }
 
-  test("That search on embed dataId and resource can be combined with other parameters") {
+  test("That searches on embedId and embedResource matches when using other parameters") {
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
@@ -667,7 +667,7 @@ class MultiSearchServiceTest
     hits.head.id should be(12)
   }
 
-  test("That search will return none on embed data id and resource search if other params doesnt match") {
+  test("That searches on embedResource and embedId doesn't match when other parameters have no hits") {
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
@@ -678,7 +678,7 @@ class MultiSearchServiceTest
     results.totalCount should be(0)
   }
 
-  test("That search on embed data-resource works") {
+  test("That search on embed data-resource matches") {
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
@@ -689,7 +689,7 @@ class MultiSearchServiceTest
     hits.head.id should be(12)
   }
 
-  test("That search on embed data-url works") {
+  test("That search on embed data-url matches") {
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
@@ -700,7 +700,7 @@ class MultiSearchServiceTest
     hits.head.id should be(12)
   }
 
-  test("That search matches embed data ids exact on query parameter") {
+  test("That search on query as embed data-resource_id matches") {
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
@@ -711,7 +711,7 @@ class MultiSearchServiceTest
     hits.head.id should be(12)
   }
 
-  test("That search matches embed data resource exact on query parameter") {
+  test("That search on query as embed data-resouce matches") {
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
@@ -720,6 +720,17 @@ class MultiSearchServiceTest
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)
+  }
+
+  test("That search on query as article id matches") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("11"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(11)
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -640,6 +640,14 @@ class MultiSearchServiceTest
     search1.totalCount should be(0)
   }
 
+  test("That search on embed data attribute only returns articles with exact attribute") {
+    val Success(results) =
+      multiSearchService.matchingQuery(searchSettings.copy(embedResource = Some("h5p")))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -680,7 +680,7 @@ class MultiSearchServiceTest
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
-          query = Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+          query = Some("query-string-without-match"),
           embedResource = Some("video"),
           embedId = Some("77")
         ))


### PR DESCRIPTION
Fixes NDLANO/Issues#2403
Fixes NDLANO/Issues#2425

Søk på artikler utvides med ny funksjonalitet:
1. Søk på artikkel-id på query-parameter skal returnere artikkel med samme id.
2. Søk på embed data-attributter (data-videoid, data-resource, data-resource_id, data-url) på query-parameter skal returnere artikler som har en embed som matcher.
3. Søk på embed data-attributter kan også gjøres med to nye parametre. embedResource (data-resource) og embedId (data-videoid, data-resource_id, data-url).

Annet:
- De fire nye data-attributtene skal være indeksert som nøkler og kun gi resultat ved nøyaktig match.
- Har skrevet nye tester. 
- Vil gjerne ha tilbakemelding på bruk av boost-parameter. Satte denne til 3 for de nye parameterne, men usikker på både bruk og hva som er mest riktig verdi her. 