### PR TITLE
#2434: Fix search-context=initial (++)

### DIFF
--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -447,14 +447,14 @@ trait SearchController {
       val fallback = booleanOrDefault(this.fallback.paramName, default = false)
 
       paramOrNone(this.scrollId.paramName) match {
-        case Some(scroll) =>
+        case Some(scroll) if !InitialScrollContextKeywords.contains(scroll) =>
           scroller.scroll(scroll, language, fallback) match {
             case Success(scrollResult) =>
               Ok(searchConverterService.toApiMultiSearchResult(scrollResult),
                  headers = scrollIdToHeader(scrollResult.scrollId))
             case Failure(ex) => errorHandler(ex)
           }
-        case None => orFunction
+        case _ => orFunction
       }
     }
 

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -94,7 +94,9 @@ trait MultiSearchService {
 
         // Only add scroll param if it is first page
         val searchWithScroll =
-          if (startAt != 0) { searchToExecute } else { searchToExecute.scroll(ElasticSearchScrollKeepAlive) }
+          if (startAt == 0 && settings.shouldScroll) {
+            searchToExecute.scroll(ElasticSearchScrollKeepAlive)
+          } else { searchToExecute }
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -552,7 +552,8 @@ class MultiSearchServiceTest
     val ids = idsForLang("all").sorted.sliding(pageSize, pageSize).toList
 
     val Success(initialSearch) =
-      multiSearchService.matchingQuery(searchSettings.copy(language = Language.AllLanguages, pageSize = pageSize))
+      multiSearchService.matchingQuery(
+        searchSettings.copy(language = Language.AllLanguages, pageSize = pageSize, shouldScroll = true))
 
     val Success(scroll1) = multiSearchService.scroll(initialSearch.scrollId.get, "all", fallback = true)
     val Success(scroll2) = multiSearchService.scroll(scroll1.scrollId.get, "all", fallback = true)


### PR DESCRIPTION
Relates to NDLANO/Issues#2434

Fikser så søk med search-context=initial (og de andre) fungerer som forventet og returnerer en search-context header
Søk uten search-context returnerer ingenting