### PR TITLE
Add embedResource and embedId params to /editorial search

### DIFF
--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -213,6 +213,8 @@ trait SearchController {
             asQueryParam(relevanceFilter),
             asQueryParam(contextFilters),
             asQueryParam(includeMissingResourceTypeGroup),
+            asQueryParam(embedResource),
+            asQueryParam(embedId)
           )
           .responseMessages(response500))
     ) {
@@ -548,7 +550,9 @@ trait SearchController {
             asQueryParam(statusFilter),
             asQueryParam(userFilter),
             asQueryParam(grepCodes),
-            asQueryParam(aggregatePaths)
+            asQueryParam(aggregatePaths),
+            asQueryParam(embedResource),
+            asQueryParam(embedId)
           )
           .authorizations("oauth2")
           .responseMessages(response500))

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -334,9 +334,7 @@ trait SearchController {
             asQueryParam(pageNo),
             asQueryParam(pageSize),
             asQueryParam(apiTypes),
-            asQueryParam(sort),
-            asQueryParam(embedResource),
-            asQueryParam(embedId)
+            asQueryParam(sort)
           )
           .responseMessages(response500))
     ) {
@@ -509,7 +507,9 @@ trait SearchController {
             asQueryParam(contextFilters),
             asQueryParam(scrollId),
             asQueryParam(grepCodes),
-            asQueryParam(aggregatePaths)
+            asQueryParam(aggregatePaths),
+            asQueryParam(embedResource),
+            asQueryParam(embedId)
           )
           .responseMessages(response500))
     ) {


### PR DESCRIPTION
Fixes NDLANO/Issues#2403. Glemte å legge til nye parametre i /editorial-søk.
Opprinnelig PR: https://github.com/NDLANO/search-api/pull/135

@gunnarvelle: embedResource og embedId skal ikke være en del av /draft søk? Fjerner i så fall dette også.