### PR TITLE
bugfix add indexing visual element and concept

### DIFF
--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
@@ -29,6 +29,6 @@ case class SearchableArticle(
     grepContexts: List[SearchableGrepContext],
     traits: List[String],
     embedAttributes: SearchableLanguageList,
-    embedResources: List[String],
-    embedIds: List[String]
+    embedResources: SearchableLanguageList,
+    embedIds: SearchableLanguageList
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
@@ -33,6 +33,6 @@ case class SearchableDraft(
     grepContexts: List[SearchableGrepContext],
     traits: List[String],
     embedAttributes: SearchableLanguageList,
-    embedResources: List[String],
-    embedIds: List[String]
+    embedResources: SearchableLanguageList,
+    embedIds: SearchableLanguageList
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -63,8 +63,6 @@ trait ArticleIndexService {
             keywordField("altText"),
             keywordField("language")
           ),
-          keywordField("embedResources"),
-          keywordField("embedIds")
         )
           ++
             generateLanguageSupportedFieldList("title", keepRaw = true) ++
@@ -74,7 +72,9 @@ trait ArticleIndexService {
           generateLanguageSupportedFieldList("introduction") ++
           generateLanguageSupportedFieldList("metaDescription") ++
           generateLanguageSupportedFieldList("tags") ++
-          generateLanguageSupportedFieldList("embedAttributes")
+          generateLanguageSupportedFieldList("embedAttributes") ++
+          generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
+          generateLanguageSupportedFieldList("embedIds", keepRaw = true)
       )
     }
   }

--- a/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -68,9 +68,7 @@ trait DraftIndexService {
             keywordField("imageId"),
             keywordField("altText"),
             keywordField("language")
-          ),
-          keywordField("embedResources"),
-          keywordField("embedIds")
+          )
         ) ++
           generateLanguageSupportedFieldList("title", keepRaw = true) ++
           generateLanguageSupportedFieldList("metaDescription") ++
@@ -78,7 +76,9 @@ trait DraftIndexService {
           generateLanguageSupportedFieldList("visualElement") ++
           generateLanguageSupportedFieldList("introduction") ++
           generateLanguageSupportedFieldList("tags") ++
-          generateLanguageSupportedFieldList("embedAttributes")
+          generateLanguageSupportedFieldList("embedAttributes") ++
+          generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
+          generateLanguageSupportedFieldList("embedIds", keepRaw = true)
       )
     }
   }

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -12,6 +12,7 @@ import com.sksamuel.elastic4s.http.search.{SearchHit, SearchResponse, Suggestion
 import com.sksamuel.elastic4s.mappings.FieldDefinition
 import com.sksamuel.elastic4s.searches.aggs.Aggregation
 import com.sksamuel.elastic4s.searches.queries.SimpleStringQuery
+import com.sksamuel.elastic4s.searches.queries.term.TermQuery
 import com.sksamuel.elastic4s.searches.sort.{FieldSort, SortOrder}
 import com.sksamuel.elastic4s.searches.suggestion.{DirectGenerator, PhraseSuggestion}
 import com.typesafe.scalalogging.LazyLogging
@@ -75,6 +76,19 @@ trait SearchService {
       } else {
         val base = simpleStringQuery(query).field(s"$field.$language", boost)
         if (searchDecompounded) base.field(s"$field.$language.decompounded", 0.1) else base
+      }
+    }
+
+    def buildTermQueryForField(
+        query: String,
+        field: String,
+        language: String,
+        fallback: Boolean
+    ): List[TermQuery] = {
+      if (language == Language.AllLanguages || fallback) {
+        Language.languageAnalyzers.map(lang => termQuery(s"$field.${lang.lang}.raw", query))
+      } else {
+        List(termQuery(s"$field.$language.raw", query))
       }
     }
 

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -349,7 +349,8 @@ object TestData {
   val article11: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(11),
     title = List(Title("Katter", "nb"), Title("Cats", "en")),
-    content = List(ArticleContent("<p>Noe om en katt</p>", "nb"), ArticleContent("<p>Something about a cat</p>", "en")),
+    content = List(ArticleContent("<embed data-resource_id=\"222\" /><p>Noe om en katt</p>", "nb"),
+                   ArticleContent("<p>Something about a cat</p>", "en")),
     tags = List(Tag(List("ikkehund"), "nb"), Tag(List("notdog"), "en")),
     visualElement = List.empty,
     introduction = List(ArticleIntroduction("Katter er store", "nb"), ArticleIntroduction("Cats are big", "en")),
@@ -362,14 +363,16 @@ object TestData {
 
   val article12: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(12),
-    title = List(Title("Ekstrastoff", "nb")),
+    title = List(Title("Ekstrastoff", "nb"), Title("extra", "en")),
     content = List(
       ArticleContent(
-        "Helsesøster H5P <embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test\" />",
+        "Helsesøster H5P <embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test\" />",
         "nb"
-      )),
+      ),
+      ArticleContent("Header <embed data-resource_id=\"222\" />", "en")
+    ),
     tags = List(Tag(List(""), "nb")),
-    visualElement = List.empty,
+    visualElement = List(VisualElement("<embed data-resource_id=\"333\">", "nb")),
     introduction = List(ArticleIntroduction("Ekstra", "nb")),
     metaDescription = List(MetaDescription("", "nb")),
     created = today.minusDays(10),
@@ -659,10 +662,10 @@ object TestData {
     metaDescription = List(MetaDescription("", "nb")),
     content = List(
       ArticleContent(
-        "<section><embed data-resource=\"concept\" data-resource_id=\"55\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test\" />",
+        "<section><embed data-resource_id=\"222\" /><embed data-resource=\"image\" data-resource_id=\"55\" data-url=\"test-image.url\"/><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test.test\" />",
         "nb"
       )),
-    visualElement = List.empty,
+    visualElement = List(VisualElement("<embed data-resource_id=\"333\">", "nb")),
     tags = List(Tag(List(""), "nb")),
     created = today.minusDays(10),
     updated = today.minusDays(5),
@@ -671,10 +674,11 @@ object TestData {
 
   val draft13: Draft = TestData.sampleDraftWithPublicDomain.copy(
     id = Option(13),
-    title = List(Title("Luringen", "nb")),
+    title = List(Title("Luringen", "nb"), Title("English title", "en")),
     introduction = List(ArticleIntroduction("Luringen", "nb")),
     metaDescription = List(MetaDescription("", "nb")),
-    content = List(ArticleContent("Helsesøster", "nb")),
+    content =
+      List(ArticleContent("Helsesøster", "nb"), ArticleContent("Header <embed data-resource_id=\"222\" />", "en")),
     visualElement = List.empty,
     tags = List(Tag(List(""), "nb")),
     created = today.minusDays(10),

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -53,9 +53,15 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
         LanguageValue("en", Seq("One english"))
       ))
 
-    val embedResources = List("test resource 1", "test resource 2")
+    val embedResources = SearchableLanguageList(
+      Seq(
+        LanguageValue("nb", List("test resource 1", "test resource 2")),
+      ))
 
-    val embedIds = List("test id 1", "test id 2")
+    val embedIds = SearchableLanguageList(
+      Seq(
+        LanguageValue("nb", List("test id 1", "test id 2")),
+      ))
 
     val metaImages = List(ArticleMetaImage("1", "alt", "nb"))
 
@@ -125,9 +131,15 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
         LanguageValue("en", Seq("One english"))
       ))
 
-    val embedResources = List("test resource 1", "test resource 2")
+    val embedResources = SearchableLanguageList(
+      Seq(
+        LanguageValue("nb", List("test resource 1", "test resource 2")),
+      ))
 
-    val embedIds = List("test id 1", "test id 2")
+    val embedIds = SearchableLanguageList(
+      Seq(
+        LanguageValue("nb", List("test id 1", "test id 2")),
+      ))
 
     val metaImages = List(ArticleMetaImage("1", "alt", "nb"))
     val filterWithNullName =

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -54,9 +54,15 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
         LanguageValue("en", Seq("One english"))
       ))
 
-    val embedResources = List("test resource 1", "test resource 2")
+    val embedResources = SearchableLanguageList(
+      Seq(
+        LanguageValue("nb", List("test resource 1", "test resource 2")),
+      ))
 
-    val embedIds = List("test id 1", "test id 2")
+    val embedIds = SearchableLanguageList(
+      Seq(
+        LanguageValue("nb", List("test id 1", "test id 2")),
+      ))
 
     val original = SearchableDraft(
       id = 100,

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -495,8 +495,8 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val Success(search) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(supportedLanguages = List("en"), language = "all"))
-    search.totalCount should be(8)
-    search.results.map(_.id) should be(Seq(2, 3, 4, 5, 6, 10, 11, 15))
+    search.totalCount should be(9)
+    search.results.map(_.id) should be(Seq(2, 3, 4, 5, 6, 10, 11, 13, 15))
 
     val Success(search2) =
       multiDraftSearchService.matchingQuery(
@@ -516,9 +516,9 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(supportedLanguages = List("en"), language = "nb"))
 
-    search.totalCount should be(5)
-    search.results.map(_.id) should be(Seq(2, 3, 4, 11, 15))
-    search.results.map(_.title.language) should be(Seq("nb", "nb", "nb", "nb", "nb"))
+    search.totalCount should be(6)
+    search.results.map(_.id) should be(Seq(2, 3, 4, 11, 13, 15))
+    search.results.map(_.title.language) should be(Seq("nb", "nb", "nb", "nb", "nb", "nb"))
   }
 
   test("That meta image are returned when searching") {
@@ -803,7 +803,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
 
   test("That searches for data-resource_id matches") {
     val Success(results) =
-      multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedId = Some("66")))
+      multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedId = Some("222")))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)
@@ -848,7 +848,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
-          embedId = Some("http://test"),
+          embedId = Some("http://test.test"),
         ))
     val hits = results.results
     results.totalCount should be(1)
@@ -866,7 +866,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.head.id should be(12)
   }
 
-  test("That search on query as embed data-resouce matches") {
+  test("That search on query as embed data-resource matches") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings.copy(
@@ -886,6 +886,52 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(11)
+  }
+
+  test("That search on embed data-content-id matches") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          embedId = Some("111"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search on embed id with language filter does only return correct language") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          embedId = Some("222"),
+          language = "en"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(13)
+  }
+
+  test("That search on embed id with language filter=all matches") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          embedId = Some("222"),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(2)
+    hits.map(_.id) should be(Seq(12, 13))
+  }
+
+  test("That search on visual element id matches") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          embedId = Some("333")
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(12))
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -470,8 +470,8 @@ class MultiSearchServiceTest
   test("That filtering on supportedLanguages works") {
     val Success(search) =
       multiSearchService.matchingQuery(searchSettings.copy(supportedLanguages = List("en"), language = "all"))
-    search.totalCount should be(7)
-    search.results.map(_.id) should be(Seq(2, 3, 4, 5, 6, 10, 11))
+    search.totalCount should be(8)
+    search.results.map(_.id) should be(Seq(2, 3, 4, 5, 6, 10, 11, 12))
 
     val Success(search2) =
       multiSearchService.matchingQuery(searchSettings.copy(supportedLanguages = List("en", "nb"), language = "all"))
@@ -488,9 +488,9 @@ class MultiSearchServiceTest
     val Success(search) =
       multiSearchService.matchingQuery(searchSettings.copy(supportedLanguages = List("en"), language = "nb"))
 
-    search.totalCount should be(4)
-    search.results.map(_.id) should be(Seq(2, 3, 4, 11))
-    search.results.map(_.title.language) should be(Seq("nb", "nb", "nb", "nb"))
+    search.totalCount should be(5)
+    search.results.map(_.id) should be(Seq(2, 3, 4, 11, 12))
+    search.results.map(_.title.language) should be(Seq("nb", "nb", "nb", "nb", "nb"))
   }
 
   test("That meta image are returned when searching") {
@@ -615,7 +615,7 @@ class MultiSearchServiceTest
 
   test("That searches for embed attributes matches") {
     val Success(search) =
-      multiSearchService.matchingQuery(searchSettings.copy(query = Some("Flubber"), language = Language.AllLanguages))
+      multiSearchService.matchingQuery(searchSettings.copy(query = Some("Flubber"), language = "nb"))
     search.results.map(_.id) should be(Seq(12))
   }
 
@@ -699,6 +699,17 @@ class MultiSearchServiceTest
     hits.head.id should be(12)
   }
 
+  test("That search on embed data-content-id matches") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          embedId = Some("111"),
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
   test("That search on embed data-url matches") {
     val Success(results) =
       multiSearchService.matchingQuery(
@@ -741,6 +752,41 @@ class MultiSearchServiceTest
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(11)
+  }
+
+  test("That search on embed id with language filter does only return correct language") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          embedId = Some("222"),
+          language = "en"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.head.id should be(12)
+  }
+
+  test("That search on embed id with language filter=all matches ") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          embedId = Some("222"),
+          language = Language.AllLanguages
+        ))
+    val hits = results.results
+    results.totalCount should be(2)
+    hits.map(_.id) should be(Seq(11, 12))
+  }
+
+  test("That search on visual element id matches ") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          embedId = Some("333")
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(12))
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {


### PR DESCRIPTION
Et par fikser for som ikke ble implementert i https://github.com/NDLANO/search-api/pull/135

Hva som er fikset:
- Forklaring-embed id var ikke tidligere indeksert. Har lagt til "data-content-id" i `getEmbedIds` for å fikse dette.
- Søk på `embedId `og `embedResource `ble ikke tidligere matchet mot visuelt element. Dette er lagt til i funksjonene `getEmbedResourcesToIndex `og `getEmbedIdsToIndex`
- embedId og embedResource søkes nå i med hensyn til language-parameter. Har laget en type query `langTermQueryFunc` for å støtte dette.

Har skrevet noen nye tester.