### PR TITLE
2483 metaimage as embedid search

### DIFF
--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -178,7 +178,8 @@ trait SearchConverterService {
     }
 
     private def getEmbedIdsToIndex(content: Seq[ArticleContent],
-                                   visualElement: Seq[VisualElement], metaImage: Seq[MetaImage]): SearchableLanguageList = {
+                                   visualElement: Seq[VisualElement],
+                                   metaImage: Seq[MetaImage]): SearchableLanguageList = {
       val contentTuples = content.map(c => c.language -> getEmbedIds(c.content))
       val visualElementTuples = visualElement.map(v => v.language -> getEmbedIds(v.resource))
       val metaImageTuples = metaImage.map(m => m.language -> List(m.url))

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -199,7 +199,7 @@ trait SearchConverterService {
       val traits = getArticleTraits(ai.content)
       val embedAttributes = getAttributesToIndex(ai.content, ai.visualElement)
       val embedResources = getEmbedResourcesToIndex(ai.content, ai.visualElement)
-      val embedIds = getEmbedIdsToIndex(ai.content, ai.visualElement)
+      val embedIds = getEmbedIdsToIndex(ai.content, ai.visualElement, ai.metaImage)
 
       val articleWithAgreement = converterService.withAgreementCopyright(ai)
 
@@ -283,7 +283,7 @@ trait SearchConverterService {
       val traits = getArticleTraits(draft.content)
       val embedAttributes = getAttributesToIndex(draft.content, draft.visualElement)
       val embedResources = getEmbedResourcesToIndex(draft.content, draft.visualElement)
-      val embedIds = getEmbedIdsToIndex(draft.content, draft.visualElement)
+      val embedIds = getEmbedIdsToIndex(draft.content, draft.visualElement, draft.metaImage)
 
       val defaultTitle = draft.title
         .sortBy(title => {

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -179,10 +179,10 @@ trait SearchConverterService {
 
     private def getEmbedIdsToIndex(content: Seq[ArticleContent],
                                    visualElement: Seq[VisualElement],
-                                   metaImage: Seq[MetaImage]): SearchableLanguageList = {
+                                   metaImage: Seq[ArticleMetaImage]): SearchableLanguageList = {
       val contentTuples = content.map(c => c.language -> getEmbedIds(c.content))
       val visualElementTuples = visualElement.map(v => v.language -> getEmbedIds(v.resource))
-      val metaImageTuples = metaImage.map(m => m.language -> List(m.url))
+      val metaImageTuples = metaImage.map(m => m.language -> List(m.imageId))
       val attrsGroupedByLanguage = (contentTuples ++ visualElementTuples ++ metaImageTuples).groupBy(_._1)
 
       val languageValues = attrsGroupedByLanguage.map {

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -284,7 +284,6 @@ trait SearchConverterService {
       val embedAttributes = getAttributesToIndex(draft.content, draft.visualElement)
       val embedResources = getEmbedResourcesToIndex(draft.content, draft.visualElement)
       val embedIds = getEmbedIdsToIndex(draft.content, draft.visualElement, draft.metaImage)
-
       val defaultTitle = draft.title
         .sortBy(title => {
           ISO639.languagePriority.reverse.indexOf(title.language)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -936,9 +936,10 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
 
   test("That search on meta image url matches ") {
     val Success(results) =
-      multiSearchService.matchingQuery(
-        searchSettings.copy(
-          embedId = Some("123")
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          embedId = Some("123"),
+          language = "all"
         ))
     val hits = results.results
     results.totalCount should be(1)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -793,7 +793,8 @@ class MultiSearchServiceTest
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings.copy(
-          embedId = Some("442")
+          embedId = Some("442"),
+          language = "all"
         ))
     val hits = results.results
     results.totalCount should be(1)


### PR DESCRIPTION
Fixes NDLANO/Issues#2483

Søk på embedId gir også treff i metabilde.


H5P-bugen relatert til denne PR-en må løses i article-api. 
PR: https://github.com/NDLANO/article-api/pull/350