### PR TITLE
Exact search works with operators

### DIFF
--- a/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -11,7 +11,6 @@ package no.ndla.searchapi.service.search
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.concurrent.Executors
-
 import com.sksamuel.elastic4s.alias.AliasAction
 import com.sksamuel.elastic4s.analyzers.{
   CompoundWordTokenFilter,
@@ -19,7 +18,8 @@ import com.sksamuel.elastic4s.analyzers.{
   HyphenationDecompounder,
   LowercaseTokenFilter,
   ShingleTokenFilter,
-  StandardTokenizer
+  StandardTokenizer,
+  WhitespaceTokenizer
 }
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.indexes.IndexRequest
@@ -222,6 +222,12 @@ trait IndexService {
         )
       )
 
+    private val customExactAnalyzer =
+      CustomAnalyzerDefinition(
+        "exact",
+        WhitespaceTokenizer
+      )
+
     def createIndexWithName(indexName: String): Try[String] = {
       if (indexWithNameExists(indexName).getOrElse(false)) {
         Success(indexName)
@@ -233,6 +239,7 @@ trait IndexService {
               trigram,
               Language.nynorskLanguageAnalyzer,
               customCompoundAnalyzer,
+              customExactAnalyzer
             )
             .indexSetting("max_result_window", SearchApiProperties.ElasticSearchIndexMaxResultWindow)
         }
@@ -380,7 +387,9 @@ trait IndexService {
           textField("trigram").analyzer("trigram"),
           textField("decompounded")
             .searchAnalyzer("standard")
-            .analyzer("compound_analyzer")
+            .analyzer("compound_analyzer"),
+          textField("exact")
+            .analyzer("exact")
         )
 
         val subFields = if (keepRaw) sf :+ keywordField("raw") else sf

--- a/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -211,7 +211,7 @@ trait IndexService {
     private val customCompoundAnalyzer =
       CustomAnalyzerDefinition(
         "compound_analyzer",
-        StandardTokenizer,
+        WhitespaceTokenizer,
         CompoundWordTokenFilter(
           name = "hyphenation_decompounder",
           `type` = HyphenationDecompounder,

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchService.scala
@@ -67,14 +67,14 @@ trait SearchService {
         searchDecompounded: Boolean
     ): SimpleStringQuery = {
       if (language == Language.AllLanguages || fallback) {
-        Language.languageAnalyzers.foldLeft(simpleStringQuery(query))(
+        Language.languageAnalyzers.foldLeft(SimpleStringQuery(query, quote_field_suffix = Some(".exact")))(
           (acc, cur) => {
             val base = acc.field(s"$field.${cur.lang}", boost)
             if (searchDecompounded) base.field(s"$field.${cur.lang}.decompounded", 0.1) else base
           }
         )
       } else {
-        val base = simpleStringQuery(query).field(s"$field.$language", boost)
+        val base = SimpleStringQuery(query, quote_field_suffix = Some(".exact")).field(s"$field.$language", boost)
         if (searchDecompounded) base.field(s"$field.$language.decompounded", 0.1) else base
       }
     }

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -662,7 +662,7 @@ object TestData {
     metaDescription = List(MetaDescription("", "nb")),
     content = List(
       ArticleContent(
-        "<section><embed data-resource_id=\"222\" /><embed data-resource=\"image\" data-resource_id=\"55\" data-url=\"test-image.url\"/><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test.test\" />",
+        "<section><p>artikkeltekst med fire deler</p><embed data-resource_id=\"222\" /><embed data-resource=\"image\" data-resource_id=\"55\" data-url=\"test-image.url\"/><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test.test\" />",
         "nb"
       )),
     visualElement = List(VisualElement("<embed data-resource_id=\"333\">", "nb")),

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -334,7 +334,8 @@ object TestData {
   val article10: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(10),
     title = List(Title("This article is in english", "en")),
-    content = List(ArticleContent("<p>Something something <em>english</em> What", "en")),
+    content =
+      List(ArticleContent("<p>artikkeltekst med fire deler</p><p>Something something <em>english</em> What", "en")),
     tags = List(Tag(List("englando"), "en")),
     visualElement = List.empty,
     introduction = List(ArticleIntroduction("Engulsk", "en")),
@@ -349,8 +350,12 @@ object TestData {
   val article11: Article = TestData.sampleArticleWithPublicDomain.copy(
     id = Option(11),
     title = List(Title("Katter", "nb"), Title("Cats", "en")),
-    content = List(ArticleContent("<embed data-resource_id=\"222\" /><p>Noe om en katt</p>", "nb"),
-                   ArticleContent("<p>Something about a cat</p>", "en")),
+    content = List(
+      ArticleContent(
+        "<p>Søkeord: delt?streng delt!streng delt&streng</p><embed data-resource_id=\"222\" /><p>Noe om en katt</p>",
+        "nb"),
+      ArticleContent("<p>Something about a cat</p>", "en")
+    ),
     tags = List(Tag(List("ikkehund"), "nb"), Tag(List("notdog"), "en")),
     visualElement = List.empty,
     introduction = List(ArticleIntroduction("Katter er store", "nb"), ArticleIntroduction("Cats are big", "en")),
@@ -366,7 +371,7 @@ object TestData {
     title = List(Title("Ekstrastoff", "nb"), Title("extra", "en")),
     content = List(
       ArticleContent(
-        "Helsesøster H5P <embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test\" />",
+        "Helsesøster H5P <p>delt-streng</p><embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\" data-resource_id=\"66\" data-url=\"http://test\" />",
         "nb"
       ),
       ArticleContent("Header <embed data-resource_id=\"222\" />", "en")

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -677,8 +677,10 @@ object TestData {
     title = List(Title("Luringen", "nb"), Title("English title", "en")),
     introduction = List(ArticleIntroduction("Luringen", "nb")),
     metaDescription = List(MetaDescription("", "nb")),
-    content =
-      List(ArticleContent("Helsesøster", "nb"), ArticleContent("Header <embed data-resource_id=\"222\" />", "en")),
+    content = List(
+      ArticleContent("<section><p>Helsesøster</p><p>Søkeord: delt?streng delt!streng delt&streng</p></section>", "nb"),
+      ArticleContent("Header <embed data-resource_id=\"222\" />", "en")
+    ),
     visualElement = List.empty,
     tags = List(Tag(List(""), "nb")),
     created = today.minusDays(10),
@@ -709,8 +711,8 @@ object TestData {
     title = List(Title("Engler og demoner", "nb")),
     introduction = List(ArticleIntroduction("Religion", "nb")),
     metaDescription = List(MetaDescription("metareligion", "nb")),
-    content =
-      List(ArticleContent("<p>Vanlig i gamle testamentet</p>", "nb"), ArticleContent("<p>Christianity!</p>", "en")),
+    content = List(ArticleContent("<section><p>Vanlig i gamle testamentet</p><p>delt-streng</p></section>", "nb"),
+                   ArticleContent("<p>Christianity!</p>", "en")),
     visualElement = List.empty,
     tags = List(Tag(List("engel"), "nb")),
     created = today.minusDays(10),

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -1028,6 +1028,18 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.map(_.id) should be(Seq(13))
   }
 
+  test("That exact search on word with spaces matches") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"artikkeltekst med fire deler\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(12))
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -946,6 +946,88 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.map(_.id) should be(Seq(10))
   }
 
+  test("That exact word search works for special characters") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"delt-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(15))
+  }
+
+  test("That exact word search works for special characters with escape") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"delt\\-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(15))
+  }
+
+  test("That multiple exact words can be searched") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"delt!streng\" \"delt?streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(13))
+  }
+
+  test("That multiple exact words can be searched with + operator") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"delt!streng\"+\"delt-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(0)
+  }
+
+  test("That multiple exact words can be searched with - operator") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"delt!streng\"+-\"delt-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(13))
+  }
+
+  test("That exact and regular words can be searched with - operator") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"delt!streng\"+-Helsesøster"),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(0)
+  }
+
+  test("That exact and regular words can be searched with + operator") {
+    val Success(results) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(
+          query = Some("\"delt!streng\" + Helsesøster"),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(13))
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -801,6 +801,100 @@ class MultiSearchServiceTest
     hits.map(_.id) should be(Seq(10))
   }
 
+  test("That exact word search works for special characters") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"delt-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(12))
+  }
+
+  test("That exact word search works for special characters with escape") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"delt\\-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(12))
+  }
+
+  test("That multiple exact words can be searched") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"delt!streng\" \"delt?streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(11))
+  }
+
+  test("That multiple exact words can be searched with + operator") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"delt!streng\"+\"delt-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(0)
+  }
+
+  test("That multiple exact words can be searched with - operator") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"delt!streng\"+-\"delt-streng\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(11))
+  }
+
+  test("That exact and regular words can be searched with - operator") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"delt!streng\"+-katt"),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(0)
+  }
+
+  test("That exact and regular words can be searched with + operator") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"delt!streng\" + katt"),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(11))
+  }
+
+  test("That exact search on word with spaces matches") {
+    val Success(results) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(
+          query = Some("\"artikkeltekst med fire deler\""),
+          language = "all"
+        ))
+    val hits = results.results
+    results.totalCount should be(1)
+    hits.map(_.id) should be(Seq(10))
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false


### PR DESCRIPTION
Fixes NDLANO/Issues#2449

I prod får man nå feil resultat dersom man forsøker eksakt med spesialtegn eller mellomrom. Dette kan feks være `"test-tekst"`eller `"test tekst"`. Den behandler spesialtegnene likt som mellomrom og man får derfor flere treff enn nødvendig. Det skal også fungere å kombinere operatorer og eksakt søk. Feks: `"test-tekst" +- feiltekst` som gir resultater som innholder `"test-tekst", `men som ikke har `feiltekst` i seg.

Har nå kommet fram til en løsning som ikke brekker de gamle testene. 
