### PR TITLE
#2527: Defaults to filter statuses based only on current

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .env
 
 .bloop/
+.bsp/
 .metals/
 project/metals.sbt
 

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val search_api = (project in file("."))
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions := Seq("-target:jvm-1.8", "-unchecked", "-deprecation", "-feature"),
     libraryDependencies ++= pactTestFramework ++ Seq(
-      "ndla" %% "network" % "0.44",
+      "ndla" %% "network" % "0.45",
       "ndla" %% "mapping" % "0.15",
       "ndla" %% "scalatestsuite" % "0.3" % "test",
       "com.typesafe.scala-logging" %% "scala-logging" % ScalaLoggingVersion,

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -161,9 +161,9 @@ trait SearchController {
          |Supported values are ${ArticleStatus.values.mkString(", ")}.""".stripMargin
     )
 
-    private val filterOtherStatuses =
+    private val includeOtherStatuses =
       Param[Option[Boolean]](
-        "filter-other-statuses",
+        "include-other-statuses",
         s"Whether or not to include the 'other' status field when filtering with '${statusFilter.paramName}' param.")
 
     private val userFilter = Param[Option[Seq[String]]](
@@ -432,7 +432,7 @@ trait SearchController {
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
       val embedResource = paramOrNone(this.embedResource.paramName)
       val embedId = paramOrNone(this.embedId.paramName)
-      val filterOtherStatuses = booleanOrDefault(this.filterOtherStatuses.paramName, default = false)
+      val filterOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
 
       MultiDraftSearchSettings(
         query = query,
@@ -459,7 +459,7 @@ trait SearchController {
         aggregatePaths = aggregatePaths,
         embedResource = embedResource,
         embedId = embedId,
-        filterOtherStatuses = filterOtherStatuses
+        includeOtherStatuses = filterOtherStatuses
       )
     }
 
@@ -562,7 +562,7 @@ trait SearchController {
             asQueryParam(aggregatePaths),
             asQueryParam(embedResource),
             asQueryParam(embedId),
-            asQueryParam(filterOtherStatuses)
+            asQueryParam(includeOtherStatuses)
           )
           .authorizations("oauth2")
           .responseMessages(response500))

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -70,10 +70,10 @@ trait SearchController {
     registerModel[ValidationError]()
     registerModel[Error]()
 
-    val response400 = ResponseMessage(400, "Validation Error", Some("ValidationError"))
-    val response403 = ResponseMessage(403, "Access Denied", Some("Error"))
-    val response404 = ResponseMessage(404, "Not found", Some("Error"))
-    val response500 = ResponseMessage(500, "Unknown error", Some("Error"))
+    val response400: ResponseMessage = ResponseMessage(400, "Validation Error", Some("ValidationError"))
+    val response403: ResponseMessage = ResponseMessage(403, "Access Denied", Some("Error"))
+    val response404: ResponseMessage = ResponseMessage(404, "Not found", Some("Error"))
+    val response500: ResponseMessage = ResponseMessage(500, "Unknown error", Some("Error"))
 
     private val correlationId =
       Param[Option[String]]("X-Correlation-ID", "User supplied correlation-id. May be omitted.")
@@ -160,6 +160,11 @@ trait SearchController {
          |A draft only needs to have one of the available statuses to be included in result (OR).
          |Supported values are ${ArticleStatus.values.mkString(", ")}.""".stripMargin
     )
+
+    private val filterOtherStatuses =
+      Param[Option[Boolean]](
+        "filter-other-statuses",
+        s"Whether or not to include the 'other' status field when filtering with '${statusFilter.paramName}' param.")
 
     private val userFilter = Param[Option[Seq[String]]](
       "users",
@@ -427,6 +432,7 @@ trait SearchController {
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
       val embedResource = paramOrNone(this.embedResource.paramName)
       val embedId = paramOrNone(this.embedId.paramName)
+      val filterOtherStatuses = booleanOrDefault(this.filterOtherStatuses.paramName, default = false)
 
       MultiDraftSearchSettings(
         query = query,
@@ -452,7 +458,8 @@ trait SearchController {
         searchDecompounded = false,
         aggregatePaths = aggregatePaths,
         embedResource = embedResource,
-        embedId = embedId
+        embedId = embedId,
+        filterOtherStatuses = filterOtherStatuses
       )
     }
 
@@ -554,7 +561,8 @@ trait SearchController {
             asQueryParam(grepCodes),
             asQueryParam(aggregatePaths),
             asQueryParam(embedResource),
-            asQueryParam(embedId)
+            asQueryParam(embedId),
+            asQueryParam(filterOtherStatuses)
           )
           .authorizations("oauth2")
           .responseMessages(response500))

--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -432,7 +432,7 @@ trait SearchController {
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
       val embedResource = paramOrNone(this.embedResource.paramName)
       val embedId = paramOrNone(this.embedId.paramName)
-      val filterOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
+      val includeOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
 
       MultiDraftSearchSettings(
         query = query,
@@ -459,7 +459,7 @@ trait SearchController {
         aggregatePaths = aggregatePaths,
         embedResource = embedResource,
         embedId = embedId,
-        includeOtherStatuses = filterOtherStatuses
+        includeOtherStatuses = includeOtherStatuses
       )
     }
 

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -36,5 +36,5 @@ case class MultiDraftSearchSettings(
     aggregatePaths: List[String],
     embedResource: Option[String],
     embedId: Option[String],
-    filterOtherStatuses: Boolean
+    includeOtherStatuses: Boolean
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -35,5 +35,6 @@ case class MultiDraftSearchSettings(
     searchDecompounded: Boolean,
     aggregatePaths: List[String],
     embedResource: Option[String],
-    embedId: Option[String]
+    embedId: Option[String],
+    filterOtherStatuses: Boolean
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -178,7 +178,7 @@ trait MultiDraftSearchService {
               ))
       }
 
-      val statusFilter = draftStatusFilter(settings.statusFilter)
+      val statusFilter = draftStatusFilter(settings.statusFilter, settings.filterOtherStatuses)
       val usersFilter = boolUsersFilter(settings.userFilter)
 
       val taxonomyContextFilter = contextTypeFilter(settings.learningResourceTypes)
@@ -216,13 +216,16 @@ trait MultiDraftSearchService {
       ).flatten
     }
 
-    private def draftStatusFilter(statuses: Seq[draft.ArticleStatus.Value]): Some[BoolQuery] = {
-      val draftStatuses = Seq("draftStatus.current", "draftStatus.other")
+    private def draftStatusFilter(statuses: Seq[draft.ArticleStatus.Value], filterOthers: Boolean): Some[BoolQuery] = {
       if (statuses.isEmpty) {
         Some(
           boolQuery().not(termQuery("draftStatus.current", ArticleStatus.ARCHIVED.toString))
         )
       } else {
+        val draftStatuses =
+          if (filterOthers) Seq("draftStatus.current", "draftStatus.other")
+          else Seq("draftStatus.current")
+
         Some(
           boolQuery().should(draftStatuses.flatMap(ds => statuses.map(s => termQuery(ds, s.toString))))
         )

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -178,7 +178,7 @@ trait MultiDraftSearchService {
               ))
       }
 
-      val statusFilter = draftStatusFilter(settings.statusFilter, settings.filterOtherStatuses)
+      val statusFilter = draftStatusFilter(settings.statusFilter, settings.includeOtherStatuses)
       val usersFilter = boolUsersFilter(settings.userFilter)
 
       val taxonomyContextFilter = contextTypeFilter(settings.learningResourceTypes)

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -216,14 +216,14 @@ trait MultiDraftSearchService {
       ).flatten
     }
 
-    private def draftStatusFilter(statuses: Seq[draft.ArticleStatus.Value], filterOthers: Boolean): Some[BoolQuery] = {
+    private def draftStatusFilter(statuses: Seq[draft.ArticleStatus.Value], includeOthers: Boolean): Some[BoolQuery] = {
       if (statuses.isEmpty) {
         Some(
           boolQuery().not(termQuery("draftStatus.current", ArticleStatus.ARCHIVED.toString))
         )
       } else {
         val draftStatuses =
-          if (filterOthers) Seq("draftStatus.current", "draftStatus.other")
+          if (includeOthers) Seq("draftStatus.current", "draftStatus.other")
           else Seq("draftStatus.current")
 
         Some(

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1168,7 +1168,7 @@ object TestData {
     aggregatePaths = List.empty,
     embedResource = None,
     embedId = None,
-    filterOtherStatuses = false
+    includeOtherStatuses = false
   )
 
   val searchableResourceTypes = List(

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1167,7 +1167,8 @@ object TestData {
     searchDecompounded = false,
     aggregatePaths = List.empty,
     embedResource = None,
-    embedId = None
+    embedId = None,
+    filterOtherStatuses = false
   )
 
   val searchableResourceTypes = List(

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -655,7 +655,16 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
         statusFilter = List(ArticleStatus.IMPORTED),
         learningResourceTypes = List(LearningResourceType.Article, LearningResourceType.TopicArticle)
       ))
-    search2.results.map(_.id) should be(Seq(12))
+    search2.results.map(_.id) should be(Seq())
+
+    val Success(search3) = multiDraftSearchService.matchingQuery(
+      multiDraftSearchSettings.copy(
+        language = Language.AllLanguages,
+        statusFilter = List(ArticleStatus.IMPORTED),
+        filterOtherStatuses = true,
+        learningResourceTypes = List(LearningResourceType.Article, LearningResourceType.TopicArticle)
+      ))
+    search3.results.map(_.id) should be(Seq(12))
   }
 
   test("Filtering for statuses should also filter learningPaths") {

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -661,7 +661,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
       multiDraftSearchSettings.copy(
         language = Language.AllLanguages,
         statusFilter = List(ArticleStatus.IMPORTED),
-        filterOtherStatuses = true,
+        includeOtherStatuses = true,
         learningResourceTypes = List(LearningResourceType.Article, LearningResourceType.TopicArticle)
       ))
     search3.results.map(_.id) should be(Seq(12))


### PR DESCRIPTION
- Defaults to filter statuses based only on current
- Adds `filter-other-statuses` flag to allow filtering both current and other.