### PR TITLE
Search on embed id now supports multiple ids in one embed

### DIFF
--- a/src/main/scala/no/ndla/searchapi/model/search/EmbedValues.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/EmbedValues.scala
@@ -8,7 +8,7 @@
 package no.ndla.searchapi.model.search
 
 case class EmbedValues(
-    id: Option[String],
+    id: List[String],
     resource: Option[String],
     language: String
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -136,24 +136,9 @@ trait SearchConverterService {
         .flatMap(getEmbedIds)
         .toList
     }
-    // To be removed
-    private def getEmbedIds(embed: Element): List[String] = {
-      val attributesToKeep = List(
-        "data-videoid",
-        "data-url",
-        "data-resource_id",
-        "data-content-id",
-      )
-
-      attributesToKeep.flatMap(attr =>
-        embed.attr(attr) match {
-          case "" => None
-          case a  => Some(a)
-      })
-    }
 
     private def getEmbedValuesFromEmbed(embed: Element, language: String): EmbedValues = {
-      EmbedValues(resource = getEmbedResource(embed), id = getEmbedId(embed), language = language)
+      EmbedValues(resource = getEmbedResource(embed), id = getEmbedIds(embed), language = language)
     }
 
     private[service] def getEmbedValues(html: String, language: String): List[EmbedValues] = {
@@ -172,7 +157,7 @@ trait SearchConverterService {
       }
     }
 
-    private def getEmbedId(embed: Element): Option[String] = {
+    private def getEmbedIds(embed: Element): List[String] = {
       val attributesToKeep = List(
         "data-videoid",
         "data-url",
@@ -180,13 +165,11 @@ trait SearchConverterService {
         "data-content-id",
       )
 
-      val attributes = attributesToKeep.map(attr =>
+      attributesToKeep.flatMap(attr =>
         embed.attr(attr) match {
           case "" => None
           case a  => Some(a)
       })
-
-      attributes.find(attr => attr.nonEmpty).getOrElse(None)
     }
 
     private def getAttributesToIndex(content: Seq[ArticleContent],
@@ -238,7 +221,7 @@ trait SearchConverterService {
       val contentTuples = content.map(c => getEmbedValues(c.content, c.language)).flatten
       val visualElementTuples = visualElement.map(v => getEmbedValues(v.resource, v.language)).flatten
       val metaImageTuples =
-        metaImage.map(m => EmbedValues(id = Some(m.imageId), resource = Some("image"), language = m.language))
+        metaImage.map(m => EmbedValues(id = List(m.imageId), resource = Some("image"), language = m.language))
       (contentTuples ++ visualElementTuples ++ metaImageTuples).toList
 
     }

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -371,7 +371,7 @@ object TestData {
     title = List(Title("Ekstrastoff", "nb"), Title("extra", "en")),
     content = List(
       ArticleContent(
-        "Helsesøster H5P <p>delt-streng</p><embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\"  /><embed data-resource=\"video\" data-resource_id=\"66\"  /><embed data-resource=\"video\" data-url=\"http://test\"/>",
+        "Helsesøster H5P <p>delt-streng</p><embed data-title=\"Flubber\" data-resource=\"h5p\" data-path=\"/resource/id\"><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\"  /><embed data-resource=\"video\" data-resource_id=\"66\"  /><embed data-resource=\"video\" data-url=\"http://test\" data-resource_id=\"test-id1\"/>",
         "nb"
       ),
       ArticleContent("Header <embed data-resource_id=\"222\" /><embed data-resource=\"concept\" />", "en")
@@ -667,7 +667,7 @@ object TestData {
     metaDescription = List(MetaDescription("", "nb")),
     content = List(
       ArticleContent(
-        "<section><p>artikkeltekst med fire deler</p><embed data-resource=\"concept\" data-resource_id=\"222\" /><embed data-resource=\"image\"  data-url=\"test-image.url\"/><embed data-resource=\"image\" data-resource_id=\"55\"/><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\"  /><embed data-resource=\"video\" data-resource_id=\"66\"  /><embed data-resource=\"video\"  data-url=\"http://test.test\" />",
+        "<section><p>artikkeltekst med fire deler</p><embed data-resource=\"concept\" data-resource_id=\"222\" /><embed data-resource=\"image\" data-resource_id=\"test-image.id\"  data-url=\"test-image.url\"/><embed data-resource=\"image\" data-resource_id=\"55\"/><embed data-resource=\"concept\" data-content-id=\"111\" data-title=\"Flubber\" /><embed data-videoid=\"77\" data-resource=\"video\"  /><embed data-resource=\"video\" data-resource_id=\"66\"  /><embed data-resource=\"video\"  data-url=\"http://test.test\" />",
         "nb"
       )),
     visualElement = List(VisualElement("<embed data-resource_id=\"333\">", "nb")),

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -53,7 +53,7 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       ))
 
     val embedResourcesAndIds =
-      List(EmbedValues(resource = Some("test resource 1"), id = Some("test id 1"), language = "nb"))
+      List(EmbedValues(resource = Some("test resource 1"), id = List("test id 1"), language = "nb"))
 
     // To be removed
     val embedResources = SearchableLanguageList(
@@ -138,7 +138,7 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       ))
 
     val embedResourcesAndIds =
-      List(EmbedValues(resource = Some("test resource 1"), id = Some("test id 1"), language = "nb"))
+      List(EmbedValues(resource = Some("test resource 1"), id = List("test id 1"), language = "nb"))
 
     val embedResources = SearchableLanguageList(
       Seq(

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -55,7 +55,7 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
       ))
 
     val embedResourcesAndIds =
-      List(EmbedValues(resource = Some("test resource 1"), id = Some("test id 1"), language = "nb"))
+      List(EmbedValues(resource = Some("test resource 1"), id = List("test id 1"), language = "nb"))
 
     // To be removed
     val embedResources = SearchableLanguageList(

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -1062,6 +1062,23 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     hits.head.id should be(12)
   }
 
+  test("That search on embed id supports embed with multiple id attributes") {
+    val Success(search1) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(embedId = Some("test-image.id"))
+      )
+    val Success(search2) =
+      multiDraftSearchService.matchingQuery(
+        multiDraftSearchSettings.copy(embedId = Some("test-image.url"))
+      )
+
+    search1.totalCount should be(1)
+    search1.results.head.id should be(12)
+    search2.totalCount should be(1)
+    search2.results.head.id should be(12)
+
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -908,6 +908,23 @@ class MultiSearchServiceTest
     hits.head.id should be(11)
   }
 
+  test("That search on embed id supports embed with multiple id attributes") {
+    val Success(search1) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(embedId = Some("test-id1"))
+      )
+    val Success(search2) =
+      multiSearchService.matchingQuery(
+        searchSettings.copy(embedId = Some("http://test"))
+      )
+
+    search1.totalCount should be(1)
+    search1.results.head.id should be(12)
+    search2.totalCount should be(1)
+    search2.results.head.id should be(12)
+
+  }
+
   def blockUntil(predicate: () => Boolean): Unit = {
     var backoff = 0
     var done = false


### PR DESCRIPTION
En enkelt embed kan inneholde flere ider (feks id og url). 

Endrer ID i EmbedValues til å være en liste for å støtte dette.

Gjelder også concept-api: https://github.com/NDLANO/concept-api/pull/84