### PR TITLE
Adds option which enables standalone indexing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,7 @@ docker / dockerfile := {
     from("adoptopenjdk/openjdk11:alpine-slim")
     run("apk", "--no-cache", "add", "ttf-dejavu")
     add(artifact, artifactTargetPath)
-    entryPoint("java", "-Dorg.scalatra.environment=production", "-Xmx1024M", "-jar", artifactTargetPath)
+    entryPoint("java", "-Dorg.scalatra.environment=production", "-Xmx2G", "-jar", artifactTargetPath)
   }
 }
 

--- a/src/main/scala/no/ndla/searchapi/JettyLauncher.scala
+++ b/src/main/scala/no/ndla/searchapi/JettyLauncher.scala
@@ -10,19 +10,15 @@ package no.ndla.searchapi
 
 import com.typesafe.scalalogging.LazyLogging
 import net.bull.javamelody.{MonitoringFilter, Parameter, ReportServlet, SessionListener}
-import no.ndla.searchapi.model.domain.{Content, ReindexResult}
+import no.ndla.searchapi.service.StandaloneIndexing
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.{DefaultServlet, FilterHolder, ServletContextHandler}
 import org.scalatra.servlet.ScalatraListener
 
 import java.util
-import java.util.concurrent.Executors
 import javax.servlet.DispatcherType
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.io.Source
 import scala.jdk.CollectionConverters.MapHasAsScala
-import scala.util.{Failure, Success, Try}
 
 object JettyLauncher extends LazyLogging {
 
@@ -33,7 +29,7 @@ object JettyLauncher extends LazyLogging {
     envMap.asScala.foreach { case (k, v) => System.setProperty(k, v) }
 
     if (SearchApiProperties.booleanOrFalse("STANDALONE_INDEXING_ENABLED")) {
-      doStandaloneIndexing()
+      StandaloneIndexing.doStandaloneIndexing()
     } else {
       val server = startServer(SearchApiProperties.ApplicationPort)
       server.join()
@@ -69,56 +65,6 @@ object JettyLauncher extends LazyLogging {
     logger.info(s"Started at port $port in $startTime ms.")
 
     server
-  }
-
-  private def doStandaloneIndexing() = {
-    val bundles = for {
-      taxonomyBundle <- ComponentRegistry.taxonomyApiClient.getTaxonomyBundle()
-      grepBundle <- ComponentRegistry.grepApiClient.getGrepBundle()
-    } yield (taxonomyBundle, grepBundle)
-
-    val start = System.currentTimeMillis()
-
-    bundles match {
-      case Failure(ex) => throw ex
-      case Success((taxonomyBundle, grepBundle)) =>
-        implicit val ec: ExecutionContextExecutorService =
-          ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(SearchApiProperties.SearchIndexes.size))
-
-        def reindexWithIndexService[C <: Content](indexService: ComponentRegistry.IndexService[C])(
-            implicit mf: Manifest[C]): Future[Try[ReindexResult]] = {
-          val reindexFuture = Future { indexService.indexDocuments(taxonomyBundle, grepBundle) }
-          reindexFuture.onComplete {
-            case Success(Success(reindexResult: ReindexResult)) =>
-              logger.info(
-                s"Completed indexing of ${reindexResult.totalIndexed} ${indexService.searchIndex} in ${reindexResult.millisUsed} ms.")
-            case Success(Failure(ex)) => logger.warn(ex.getMessage, ex)
-            case Failure(ex) =>
-              logger.warn(s"Unable to create index '${indexService.searchIndex}': " + ex.getMessage, ex)
-          }
-
-          reindexFuture
-        }
-
-        val result = Await.result(
-          Future.sequence(
-            Seq(
-              reindexWithIndexService(ComponentRegistry.learningPathIndexService),
-              reindexWithIndexService(ComponentRegistry.articleIndexService),
-              reindexWithIndexService(ComponentRegistry.draftIndexService)
-            )),
-          Duration.Inf
-        )
-
-        result.foreach(x =>
-          if (x.isFailure) {
-            logger.error("Indexing failed...")
-            sys.exit(1)
-        })
-
-        logger.info(s"Reindexing all indexes took ${System.currentTimeMillis() - start} ms...")
-        sys.exit(0)
-    }
   }
 
 }

--- a/src/main/scala/no/ndla/searchapi/JettyLauncher.scala
+++ b/src/main/scala/no/ndla/searchapi/JettyLauncher.scala
@@ -8,25 +8,21 @@
 
 package no.ndla.searchapi
 
-import java.util
 import com.typesafe.scalalogging.LazyLogging
-
-import javax.servlet.DispatcherType
 import net.bull.javamelody.{MonitoringFilter, Parameter, ReportServlet, SessionListener}
-import no.ndla.searchapi.model.domain.{Content, ReindexResult, RequestInfo}
-import no.ndla.searchapi.service.search.IndexService
+import no.ndla.searchapi.model.domain.{Content, ReindexResult}
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.{DefaultServlet, FilterHolder, ServletContextHandler}
 import org.scalatra.servlet.ScalatraListener
 
+import java.util
 import java.util.concurrent.Executors
-import scala.collection.immutable.{AbstractSeq, LinearSeq}
+import javax.servlet.DispatcherType
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.io.Source
 import scala.jdk.CollectionConverters.MapHasAsScala
 import scala.util.{Failure, Success, Try}
-import scala.xml.NodeSeq
 
 object JettyLauncher extends LazyLogging {
 
@@ -58,7 +54,7 @@ object JettyLauncher extends LazyLogging {
     val monitoringFilter = new FilterHolder(new MonitoringFilter())
     monitoringFilter.setInitParameter(Parameter.APPLICATION_NAME.getCode, SearchApiProperties.ApplicationName)
     SearchApiProperties.Environment match {
-      case "local" => None
+      case "local" =>
       case _ =>
         monitoringFilter.setInitParameter(Parameter.CLOUDWATCH_NAMESPACE.getCode,
                                           "NDLA/APP".replace("APP", SearchApiProperties.ApplicationName))

--- a/src/main/scala/no/ndla/searchapi/JettyLauncher.scala
+++ b/src/main/scala/no/ndla/searchapi/JettyLauncher.scala
@@ -9,22 +9,42 @@
 package no.ndla.searchapi
 
 import java.util
-
 import com.typesafe.scalalogging.LazyLogging
+
 import javax.servlet.DispatcherType
 import net.bull.javamelody.{MonitoringFilter, Parameter, ReportServlet, SessionListener}
+import no.ndla.searchapi.model.domain.{Content, ReindexResult, RequestInfo}
+import no.ndla.searchapi.service.search.IndexService
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.{DefaultServlet, FilterHolder, ServletContextHandler}
 import org.scalatra.servlet.ScalatraListener
 
+import java.util.concurrent.Executors
+import scala.collection.immutable.{AbstractSeq, LinearSeq}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.io.Source
 import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.util.{Failure, Success, Try}
+import scala.xml.NodeSeq
 
 object JettyLauncher extends LazyLogging {
 
-  def startServer(port: Int): Server = {
+  def main(args: Array[String]): Unit = {
     logger.info(Source.fromInputStream(getClass.getResourceAsStream("/log-license.txt")).mkString)
 
+    val envMap = System.getenv()
+    envMap.asScala.foreach { case (k, v) => System.setProperty(k, v) }
+
+    if (SearchApiProperties.booleanOrFalse("STANDALONE_INDEXING_ENABLED")) {
+      doStandaloneIndexing()
+    } else {
+      val server = startServer(SearchApiProperties.ApplicationPort)
+      server.join()
+    }
+  }
+
+  def startServer(port: Int): Server = {
     val startMillis = System.currentTimeMillis()
 
     val context = new ServletContextHandler()
@@ -55,11 +75,54 @@ object JettyLauncher extends LazyLogging {
     server
   }
 
-  def main(args: Array[String]): Unit = {
-    val envMap = System.getenv()
-    envMap.asScala.foreach { case (k, v) => System.setProperty(k, v) }
+  private def doStandaloneIndexing() = {
+    val bundles = for {
+      taxonomyBundle <- ComponentRegistry.taxonomyApiClient.getTaxonomyBundle()
+      grepBundle <- ComponentRegistry.grepApiClient.getGrepBundle()
+    } yield (taxonomyBundle, grepBundle)
 
-    val server = startServer(SearchApiProperties.ApplicationPort)
-    server.join()
+    val start = System.currentTimeMillis()
+
+    bundles match {
+      case Failure(ex) => throw ex
+      case Success((taxonomyBundle, grepBundle)) =>
+        implicit val ec: ExecutionContextExecutorService =
+          ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(SearchApiProperties.SearchIndexes.size))
+
+        def reindexWithIndexService[C <: Content](indexService: ComponentRegistry.IndexService[C])(
+            implicit mf: Manifest[C]): Future[Try[ReindexResult]] = {
+          val reindexFuture = Future { indexService.indexDocuments(taxonomyBundle, grepBundle) }
+          reindexFuture.onComplete {
+            case Success(Success(reindexResult: ReindexResult)) =>
+              logger.info(
+                s"Completed indexing of ${reindexResult.totalIndexed} ${indexService.searchIndex} in ${reindexResult.millisUsed} ms.")
+            case Success(Failure(ex)) => logger.warn(ex.getMessage, ex)
+            case Failure(ex) =>
+              logger.warn(s"Unable to create index '${indexService.searchIndex}': " + ex.getMessage, ex)
+          }
+
+          reindexFuture
+        }
+
+        val result = Await.result(
+          Future.sequence(
+            Seq(
+              reindexWithIndexService(ComponentRegistry.learningPathIndexService),
+              reindexWithIndexService(ComponentRegistry.articleIndexService),
+              reindexWithIndexService(ComponentRegistry.draftIndexService)
+            )),
+          Duration.Inf
+        )
+
+        result.foreach(x =>
+          if (x.isFailure) {
+            logger.error("Indexing failed...")
+            sys.exit(1)
+        })
+
+        logger.info(s"Reindexing all indexes took ${System.currentTimeMillis() - start} ms...")
+        sys.exit(0)
+    }
   }
+
 }

--- a/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
+++ b/src/main/scala/no/ndla/searchapi/SearchApiProperties.scala
@@ -15,7 +15,7 @@ import no.ndla.searchapi.model.search.SearchType
 import scala.util.Properties._
 
 object SearchApiProperties extends LazyLogging {
-  val Environment = propOrElse("NDLA_ENVIRONMENT", "local")
+  val Environment: String = propOrElse("NDLA_ENVIRONMENT", "local")
   val ApplicationName = "search-api"
   val Auth0LoginEndpoint = s"https://${AuthUser.getAuth0HostForEnv(Environment)}/authorize"
 
@@ -27,7 +27,7 @@ object SearchApiProperties extends LazyLogging {
   val CorrelationIdKey = "correlationID"
   val CorrelationIdHeader = "X-Correlation-ID"
 
-  lazy val Domain = Domains.get(Environment)
+  lazy val Domain: String = Domains.get(Environment)
 
   val DraftApiUrl: String = s"http://${propOrElse("DRAFT_API_HOST", "draft-api.ndla-local")}"
   val ArticleApiUrl: String = s"http://${propOrElse("ARTICLE_API_HOST", "article-api.ndla-local")}"
@@ -67,11 +67,13 @@ object SearchApiProperties extends LazyLogging {
     "raw-image" -> s"$Domain/image-api/raw/id"
   )
 
-  def booleanProp(key: String) = prop(key).toBoolean
+  def booleanProp(key: String): Boolean = prop(key).toBoolean
 
   def prop(key: String): String = {
     propOrElse(key, throw new RuntimeException(s"Unable to load property $key"))
   }
 
   def propOrElse(key: String, default: => String): String = envOrElse(key, default)
+
+  def booleanOrFalse(key: String): Boolean = propOrElse(key, "false").toBoolean
 }

--- a/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
+++ b/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
@@ -49,8 +49,7 @@ object StandaloneIndexing extends LazyLogging {
 
     implicit val formats: Formats = DefaultFormats
     val errorTitle = s"search-api ${SearchApiProperties.Environment}"
-    val errorBody =
-      s"(Dette er jonas som tester, ignorer dette) Standalone indexing failed with:\n${errors.mkString("\n")}"
+    val errorBody = s"Standalone indexing failed with:\n${errors.mkString("\n")}"
 
     val errorAttachment = SlackAttachment(
       color = "#ff0000",
@@ -117,10 +116,9 @@ object StandaloneIndexing extends LazyLogging {
     }
 
     val errors = reindexResult.collect {
-      case Failure(ex) => {
+      case Failure(ex) =>
         logger.error("Indexing failed...", ex)
         ex.getMessage
-      }
     }
 
     if (errors.nonEmpty) {

--- a/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
+++ b/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
@@ -1,3 +1,9 @@
+/*
+ * Part of NDLA search-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
 package no.ndla.searchapi.service
 
 import com.typesafe.scalalogging.LazyLogging
@@ -14,6 +20,10 @@ import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorServic
 import scala.util.{Failure, Success, Try}
 import java.time.Instant
 
+/**
+  * This part of search-api is used for indexing in a separate instance.
+  * If enabled, this will also send a slack message if the indexing fails for any reason.
+  * */
 object StandaloneIndexing extends LazyLogging {
   case class SlackAttachment(
       title: String,

--- a/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
+++ b/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
@@ -1,0 +1,124 @@
+package no.ndla.searchapi.service
+
+import com.typesafe.scalalogging.LazyLogging
+import no.ndla.searchapi.SearchApiProperties.{booleanOrFalse, prop, propOrElse}
+import no.ndla.searchapi.model.domain.{Content, ReindexResult}
+import no.ndla.searchapi.{ComponentRegistry, SearchApiProperties}
+import org.json4s.{DefaultFormats, Formats}
+import org.json4s.native.Serialization
+import scalaj.http.Http
+
+import java.util.concurrent.Executors
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.util.{Failure, Success, Try}
+import java.time.Instant
+
+object StandaloneIndexing extends LazyLogging {
+  case class SlackAttachment(
+      title: String,
+      color: String,
+      ts: String,
+      text: String
+  )
+
+  case class SlackPayload(
+      channel: String,
+      username: String,
+      attachments: Seq[SlackAttachment]
+  )
+
+  def sendSlackError(errors: Seq[String]): Unit = {
+    val enableSlackMessageFlag = "SLACK_ERROR_ENABLED"
+    if (!booleanOrFalse(enableSlackMessageFlag)) {
+      logger.info(s"Skipping sending message to slack because $enableSlackMessageFlag...")
+      return
+    } else {
+      logger.info("Sending message to slack...")
+    }
+
+    implicit val formats: Formats = DefaultFormats
+    val errorTitle = s"search-api ${SearchApiProperties.Environment}"
+    val errorBody =
+      s"(Dette er jonas som tester, ignorer dette) Standalone indexing failed with:\n${errors.mkString("\n")}"
+
+    val errorAttachment = SlackAttachment(
+      color = "#ff0000",
+      ts = Instant.now.getEpochSecond.toString,
+      title = errorTitle,
+      text = errorBody
+    )
+
+    val payload = SlackPayload(
+      channel = propOrElse("SLACK_CHANNEL", "ndla-indexing-errors"),
+      username = propOrElse("SLACK_USERNAME", "indexbot"),
+      attachments = Seq(errorAttachment)
+    )
+
+    val body = Serialization.write(payload)
+
+    Http(url = propOrElse("SLACK_URL", "https://slack.com/api/chat.postMessage"))
+      .postData(data = body)
+      .header("Content-Type", "application/json")
+      .header("Authorization", s"Bearer ${prop(s"SLACK_TOKEN")}")
+      .asString
+  }
+
+  def doStandaloneIndexing(): Nothing = {
+    val bundles = for {
+      taxonomyBundle <- ComponentRegistry.taxonomyApiClient.getTaxonomyBundle()
+      grepBundle <- ComponentRegistry.grepApiClient.getGrepBundle()
+    } yield (taxonomyBundle, grepBundle)
+
+    val start = System.currentTimeMillis()
+
+    val reindexResult = bundles match {
+      case Failure(ex) => Seq(Failure(ex))
+      case Success((taxonomyBundle, grepBundle)) =>
+        implicit val ec: ExecutionContextExecutorService =
+          ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(SearchApiProperties.SearchIndexes.size))
+
+        def reindexWithIndexService[C <: Content](indexService: ComponentRegistry.IndexService[C])(
+            implicit mf: Manifest[C]): Future[Try[ReindexResult]] = {
+          val reindexFuture = Future {
+            indexService.indexDocuments(taxonomyBundle, grepBundle)
+          }
+          reindexFuture.onComplete {
+            case Success(Success(reindexResult: ReindexResult)) =>
+              logger.info(
+                s"Completed indexing of ${reindexResult.totalIndexed} ${indexService.searchIndex} in ${reindexResult.millisUsed} ms.")
+            case Success(Failure(ex)) => logger.warn(ex.getMessage, ex)
+            case Failure(ex) =>
+              logger.warn(s"Unable to create index '${indexService.searchIndex}': " + ex.getMessage, ex)
+          }
+
+          reindexFuture
+        }
+
+        Await.result(
+          Future.sequence(
+            Seq(
+              reindexWithIndexService(ComponentRegistry.learningPathIndexService),
+              reindexWithIndexService(ComponentRegistry.articleIndexService),
+              reindexWithIndexService(ComponentRegistry.draftIndexService)
+            )),
+          Duration.Inf
+        )
+    }
+
+    val errors = reindexResult.collect {
+      case Failure(ex) => {
+        logger.error("Indexing failed...", ex)
+        ex.getMessage
+      }
+    }
+
+    if (errors.nonEmpty) {
+      sendSlackError(errors)
+      sys.exit(1)
+    }
+
+    logger.info(s"Reindexing all indexes took ${System.currentTimeMillis() - start} ms...")
+    sys.exit(0)
+  }
+}

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -218,8 +218,8 @@ trait SearchConverterService {
     private def getEmbedResourcesAndIdsToIndex(content: Seq[ArticleContent],
                                                visualElement: Seq[VisualElement],
                                                metaImage: Seq[ArticleMetaImage]): List[EmbedValues] = {
-      val contentTuples = content.map(c => getEmbedValues(c.content, c.language)).flatten
-      val visualElementTuples = visualElement.map(v => getEmbedValues(v.resource, v.language)).flatten
+      val contentTuples = content.flatMap(c => getEmbedValues(c.content, c.language))
+      val visualElementTuples = visualElement.flatMap(v => getEmbedValues(v.resource, v.language))
       val metaImageTuples =
         metaImage.map(m => EmbedValues(id = List(m.imageId), resource = Some("image"), language = m.language))
       (contentTuples ++ visualElementTuples ++ metaImageTuples).toList


### PR DESCRIPTION
- Legger til `STANDALONE_INDEXING_ENABLED` miljøvariabel, denne:
    - Starter indeksering ved oppstart
    - Spinner _ikke_ opp webserveren
    - Avslutter prosessen når indeksering avslutter (eller feiler)
- Nye indekser opprettes med `number_of_replicas=0` for raskere indeksering (Den settes til 1 igjen når indekseringen fullfører)