### PR TITLE
#2609: Filter out teacher and student available articles in multisearch

### DIFF
--- a/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
+++ b/src/main/scala/no/ndla/searchapi/ComponentRegistry.scala
@@ -40,6 +40,7 @@ object ComponentRegistry
     with SearchService
     with ApiSearchService
     with SearchController
+    with FeideApiClient
     with InternController
     with User
     with SearchApiClient
@@ -62,6 +63,7 @@ object ComponentRegistry
   lazy val imageApiClient = new ImageApiClient(ImageApiUrl)
   lazy val audioApiClient = new AudioApiClient(AudioApiUrl)
   lazy val articleApiClient = new ArticleApiClient(ArticleApiUrl)
+  lazy val feideApiClient = new FeideApiClient
   lazy val SearchClients = Map[String, SearchApiClient](
     draftApiClient.name -> draftApiClient,
     learningPathApiClient.name -> learningPathApiClient,

--- a/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/NdlaController.scala
@@ -9,12 +9,15 @@
 package no.ndla.searchapi.controller
 
 import com.typesafe.scalalogging.LazyLogging
+
 import javax.servlet.http.HttpServletRequest
 import no.ndla.network.{ApplicationUrl, AuthUser, CorrelationID}
 import no.ndla.searchapi.SearchApiProperties.{CorrelationIdHeader, CorrelationIdKey}
+import no.ndla.searchapi.integration.FeideApiClient
 import no.ndla.searchapi.model.api.{
   AccessDeniedException,
   Error,
+  FeideApiException,
   InvalidIndexBodyException,
   ResultWindowTooLargeException,
   TaxonomyException,

--- a/src/main/scala/no/ndla/searchapi/integration/FeideApiClient.scala
+++ b/src/main/scala/no/ndla/searchapi/integration/FeideApiClient.scala
@@ -25,9 +25,9 @@ case class FeideExtendedUserInfo(
   def isStudent: Boolean = this.eduPersonAffiliation.contains("student")
 
   def isTeacher: Boolean = {
-    this.eduPersonPrimaryAffiliation.contains("staff") ||
-    this.eduPersonPrimaryAffiliation.contains("faculty") ||
-    this.eduPersonPrimaryAffiliation.contains("employee")
+    this.eduPersonAffiliation.contains("staff") ||
+    this.eduPersonAffiliation.contains("faculty") ||
+    this.eduPersonAffiliation.contains("employee")
   }
 
   def availabilities: List[Availability.Value] = {

--- a/src/main/scala/no/ndla/searchapi/integration/FeideApiClient.scala
+++ b/src/main/scala/no/ndla/searchapi/integration/FeideApiClient.scala
@@ -1,5 +1,5 @@
 /*
- * Part of NDLA article-api.
+ * Part of NDLA search-api.
  * Copyright (C) 2021 NDLA
  *
  * See LICENSE

--- a/src/main/scala/no/ndla/searchapi/integration/FeideApiClient.scala
+++ b/src/main/scala/no/ndla/searchapi/integration/FeideApiClient.scala
@@ -1,0 +1,97 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.searchapi.integration
+
+import com.typesafe.scalalogging.LazyLogging
+import no.ndla.network.NdlaClient
+import no.ndla.network.model.HttpRequestException
+import no.ndla.searchapi.model.domain.article.Availability
+import org.json4s.native.JsonMethods
+import org.json4s.{DefaultFormats, Formats}
+import scalaj.http.{Http, HttpRequest, HttpResponse}
+
+import scala.util.{Failure, Success, Try}
+
+case class FeideExtendedUserInfo(
+    displayName: String,
+    eduPersonAffiliation: Seq[String],
+    eduPersonPrimaryAffiliation: String
+) {
+  def isStudent: Boolean = this.eduPersonAffiliation.contains("student")
+
+  def isTeacher: Boolean = {
+    this.eduPersonPrimaryAffiliation.contains("staff") ||
+    this.eduPersonPrimaryAffiliation.contains("faculty") ||
+    this.eduPersonPrimaryAffiliation.contains("employee")
+  }
+
+  def availabilities: List[Availability.Value] = {
+    if (this.isTeacher) {
+      List(
+        Availability.everyone,
+        Availability.teacher,
+        Availability.student
+      )
+    } else if (this.isStudent) {
+      List(
+        Availability.everyone,
+        Availability.student
+      )
+    } else {
+      List.empty
+    }
+  }
+}
+
+trait FeideApiClient {
+  this: NdlaClient =>
+  val feideApiClient: FeideApiClient
+
+  class FeideApiClient extends LazyLogging {
+
+    private val userInfoEndpoint = "https://api.dataporten.no/userinfo/v1/userinfo"
+
+    private val feideTimeout = 1000 * 30
+
+    def getUser(accessToken: String): Try[FeideExtendedUserInfo] = {
+      val request =
+        Http(userInfoEndpoint)
+          .timeout(feideTimeout, feideTimeout)
+          .header("Authorization", s"Bearer $accessToken")
+
+      implicit val formats: DefaultFormats.type = DefaultFormats
+
+      for {
+        response <- doRequest(request)
+        parsed <- parseResponse[FeideExtendedUserInfo](response)
+      } yield parsed
+    }
+
+    private def parseResponse[T](response: HttpResponse[String])(implicit mf: Manifest[T], formats: Formats): Try[T] = {
+      Try(JsonMethods.parse(response.body).camelizeKeys.extract[T]) match {
+        case Success(extracted) => Success(extracted)
+        case Failure(ex) =>
+          logger.error("Could not parse response from feide.", ex)
+          Failure(new HttpRequestException(s"Could not parse response ${response.body}", Some(response)))
+      }
+    }
+
+    private def doRequest(request: HttpRequest): Try[HttpResponse[String]] = {
+      Try(request.asString).flatMap(response => {
+        if (response.isError) {
+          Failure(new HttpRequestException(
+            s"Received error ${response.code} ${response.statusLine} when calling ${request.url}. Body was ${response.body}",
+            Some(response)))
+        } else {
+          Success(response)
+        }
+      })
+    }
+  }
+
+}

--- a/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
+++ b/src/main/scala/no/ndla/searchapi/integration/SearchApiClient.scala
@@ -12,7 +12,7 @@ import io.lemonlabs.uri.dsl._
 import no.ndla.network.NdlaClient
 import no.ndla.searchapi.SearchApiProperties
 import no.ndla.searchapi.model.api.ApiSearchException
-import no.ndla.searchapi.model.domain.article.LearningResourceType
+import no.ndla.searchapi.model.domain.article.{Availability, LearningResourceType}
 import no.ndla.searchapi.model.domain.draft.ArticleStatus
 import no.ndla.searchapi.model.domain.learningpath._
 import no.ndla.searchapi.model.domain.{ApiSearchResults, DomainDumpResults, RequestInfo, SearchParams}
@@ -89,7 +89,8 @@ trait SearchApiClient {
           new EnumNameSerializer(StepType) +
           new EnumNameSerializer(StepStatus) +
           new EnumNameSerializer(EmbedType) +
-          new EnumNameSerializer(LearningResourceType) ++
+          new EnumNameSerializer(LearningResourceType) +
+          new EnumNameSerializer(Availability) ++
           org.json4s.ext.JodaTimeSerializers.all
 
       ndlaClient.fetchWithForwardedAuth[T](Http((baseUrl / path).addParams(params.toList)).timeout(timeout, timeout))

--- a/src/main/scala/no/ndla/searchapi/model/api/Error.scala
+++ b/src/main/scala/no/ndla/searchapi/model/api/Error.scala
@@ -74,3 +74,4 @@ case class AccessDeniedException(message: String) extends RuntimeException(messa
 case class InvalidIndexBodyException(message: String = Error.INVALID_BODY_DESCRIPTION) extends RuntimeException(message)
 case class TaxonomyException(message: String) extends RuntimeException(message)
 case class GrepException(message: String) extends RuntimeException(message)
+case class FeideApiException(message: String, ex: Throwable) extends RuntimeException(message)

--- a/src/main/scala/no/ndla/searchapi/model/domain/article/Article.scala
+++ b/src/main/scala/no/ndla/searchapi/model/domain/article/Article.scala
@@ -7,6 +7,7 @@
 
 package no.ndla.searchapi.model.domain.article
 
+import no.ndla.searchapi.model.domain.article.RelatedContentLink.RelatedContent
 import no.ndla.searchapi.model.domain.{Content, Tag, Title}
 import org.joda.time.DateTime
 import org.json4s.FieldSerializer
@@ -27,15 +28,18 @@ case class Article(id: Option[Long],
                    updatedBy: String,
                    published: DateTime,
                    articleType: LearningResourceType.Value,
-                   grepCodes: Seq[String])
+                   grepCodes: Seq[String],
+                   conceptIds: Seq[Long],
+                   availability: Availability.Value = Availability.everyone,
+                   relatedContent: Seq[RelatedContent])
     extends Content
 
 object LearningResourceType extends Enumeration {
-  val Article = Value("standard")
-  val TopicArticle = Value("topic-article")
-  val LearningPath = Value("learningpath")
+  val Article: LearningResourceType.Value = Value("standard")
+  val TopicArticle: LearningResourceType.Value = Value("topic-article")
+  val LearningPath: LearningResourceType.Value = Value("learningpath")
 
-  def all = LearningResourceType.values.map(_.toString).toList
+  def all: List[String] = LearningResourceType.values.map(_.toString).toList
 
   def valueOf(s: String): Option[LearningResourceType.Value] = LearningResourceType.values.find(_.toString == s)
 }

--- a/src/main/scala/no/ndla/searchapi/model/domain/article/Availability.scala
+++ b/src/main/scala/no/ndla/searchapi/model/domain/article/Availability.scala
@@ -1,0 +1,24 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.searchapi.model.domain.article
+
+object Availability extends Enumeration {
+  val everyone, student, teacher = Value
+
+  def valueOf(s: String): Option[Availability.Value] = {
+    Availability.values.find(_.toString == s)
+  }
+
+  def valueOf(s: Option[String]): Option[Availability.Value] = {
+    s match {
+      case None    => None
+      case Some(s) => valueOf(s)
+    }
+  }
+
+}

--- a/src/main/scala/no/ndla/searchapi/model/domain/article/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/searchapi/model/domain/article/RelatedContentLink.scala
@@ -1,0 +1,7 @@
+package no.ndla.searchapi.model.domain.article
+
+case class RelatedContentLink(title: String, url: String)
+
+object RelatedContentLink {
+  type RelatedContent = Either[RelatedContentLink, Long]
+}

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
@@ -34,4 +34,5 @@ case class SearchableArticle(
     // To be removed
     embedIds: SearchableLanguageList,
     embedResourcesAndIds: List[EmbedValues],
+    availability: String,
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -8,7 +8,7 @@
 package no.ndla.searchapi.model.search.settings
 
 import no.ndla.searchapi.model.domain.Sort
-import no.ndla.searchapi.model.domain.article.LearningResourceType
+import no.ndla.searchapi.model.domain.article.{Availability, LearningResourceType}
 
 case class SearchSettings(
     query: Option[String],
@@ -30,5 +30,6 @@ case class SearchSettings(
     filterByNoResourceType: Boolean, // If true, and resourceTypes is empty, results will have no resource-type or taxonomy context
     aggregatePaths: List[String],
     embedResource: Option[String],
-    embedId: Option[String]
+    embedId: Option[String],
+    availability: List[Availability.Value]
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -60,6 +60,7 @@ trait ArticleIndexService {
             keywordField("grepContexts.code"),
             textField("grepContexts.title"),
             keywordField("traits"),
+            keywordField("availability"),
             getTaxonomyContextMapping,
             nestedField("embedResourcesAndIds").fields(
               keywordField("resource"),

--- a/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -47,6 +47,11 @@ trait IndexService {
     val documentType: String
     val searchIndex: String
 
+    // Setting this to suppress the warning, since it will default to '1' in the new version.
+    // The value '5' was chosen since that is what was the default earlier (which worked fine).
+    // However there are probably more optimal values.
+    val indexShards: Int = 5
+
     val shingle: ShingleTokenFilter =
       ShingleTokenFilter(name = "shingle", minShingleSize = Some(2), maxShingleSize = Some(3))
 
@@ -236,6 +241,8 @@ trait IndexService {
       } else {
         val response = e4sClient.execute {
           createIndex(indexName)
+            .shards(indexShards)
+            .includeTypeName(true) // Explicitly set to suppress warnings about upgrade, should probably be removed after upgrade.
             .mappings(getMapping)
             .analysis(
               trigram,

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -18,8 +18,9 @@ import no.ndla.searchapi.SearchApiProperties.{
   ElasticSearchScrollKeepAlive,
   SearchIndexes
 }
-import no.ndla.searchapi.integration.Elastic4sClient
+import no.ndla.searchapi.integration.{Elastic4sClient, FeideApiClient}
 import no.ndla.searchapi.model.api.ResultWindowTooLargeException
+import no.ndla.searchapi.model.domain.article.Availability
 import no.ndla.searchapi.model.domain.{Language, RequestInfo, SearchResult}
 import no.ndla.searchapi.model.search.SearchType
 import no.ndla.searchapi.model.search.settings.SearchSettings
@@ -165,6 +166,11 @@ trait MultiSearchService {
             )
           )
 
+      val availsToFilterOut = Availability.values -- (settings.availability.toSet + Availability.everyone)
+      val availabilityFilter = Some(
+        not(availsToFilterOut.toSeq.map(a => termQuery("availability", a.toString)))
+      )
+
       List(
         licenseFilter,
         idFilter,
@@ -176,7 +182,8 @@ trait MultiSearchService {
         supportedLanguageFilter,
         taxonomyRelevanceFilter,
         grepCodesFilter,
-        embedResourceAndIdFilter
+        embedResourceAndIdFilter,
+        availabilityFilter
       ).flatten
     }
 

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -281,7 +281,8 @@ trait SearchConverterService {
           // To be removed
           embedResources = embedResources,
           // To be removed
-          embedIds = embedIds
+          embedIds = embedIds,
+          availability = articleWithAgreement.availability.toString
         ))
 
     }

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -152,6 +152,9 @@ object TestData {
     "ndalId54321",
     today.minusDays(2),
     LearningResourceType.Article,
+    Seq.empty,
+    Seq.empty,
+    Availability.everyone,
     Seq.empty
   )
 
@@ -172,6 +175,9 @@ object TestData {
     "ndalId54321",
     today,
     LearningResourceType.Article,
+    Seq.empty,
+    Seq.empty,
+    Availability.everyone,
     Seq.empty
   )
 
@@ -192,6 +198,9 @@ object TestData {
     "ndalId54321",
     today,
     LearningResourceType.Article,
+    Seq.empty,
+    Seq.empty,
+    Availability.everyone,
     Seq.empty
   )
 
@@ -386,6 +395,26 @@ object TestData {
     articleType = LearningResourceType.Article
   )
 
+  val article13: Article = TestData.sampleArticleWithPublicDomain.copy(
+    id = Option(13),
+    title = List(Title("Hemmelig og utilgjengelig", "nb")),
+    content = List(
+      ArticleContent(
+        "Hemmelig",
+        "nb"
+      )
+    ),
+    tags = List(Tag(List(""), "nb")),
+    visualElement = List(),
+    introduction = List(ArticleIntroduction("Intro", "nb")),
+    metaDescription = List(MetaDescription("", "nb")),
+    created = today.minusDays(10),
+    updated = today.minusDays(5),
+    published = today.minusDays(5),
+    articleType = LearningResourceType.Article,
+    availability = Availability.teacher
+  )
+
   val articlesToIndex: Seq[Article] = List(
     article1,
     article2,
@@ -398,10 +427,11 @@ object TestData {
     article9,
     article10,
     article11,
-    article12
+    article12,
+    article13
   )
 
-  val emptyDomainArticle = Article(
+  val emptyDomainArticle: Article = Article(
     id = None,
     revision = None,
     title = Seq.empty,
@@ -418,10 +448,13 @@ object TestData {
     updatedBy = "",
     published = today,
     articleType = LearningResourceType.Article,
-    grepCodes = Seq.empty
+    grepCodes = Seq.empty,
+    conceptIds = Seq.empty,
+    availability = Availability.everyone,
+    relatedContent = Seq.empty
   )
 
-  val emptyDomainDraft = Draft(
+  val emptyDomainDraft: Draft = Draft(
     id = None,
     revision = None,
     status = draft.Status(draft.ArticleStatus.DRAFT, Set.empty),
@@ -1160,7 +1193,7 @@ object TestData {
     tverrfagligeTemaer = List(GrepElement("TT2", Seq(GrepTitle("default", "Demokrati og medborgerskap"))))
   )
 
-  val searchSettings = SearchSettings(
+  val searchSettings: SearchSettings = SearchSettings(
     query = None,
     fallback = false,
     language = Language.DefaultLanguage,
@@ -1180,10 +1213,11 @@ object TestData {
     filterByNoResourceType = false,
     aggregatePaths = List.empty,
     embedResource = None,
-    embedId = None
+    embedId = None,
+    availability = List.empty
   )
 
-  val multiDraftSearchSettings = MultiDraftSearchSettings(
+  val multiDraftSearchSettings: MultiDraftSearchSettings = MultiDraftSearchSettings(
     query = None,
     noteQuery = None,
     fallback = false,

--- a/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
+++ b/src/test/scala/no/ndla/searchapi/TestEnvironment.scala
@@ -27,6 +27,7 @@ trait TestEnvironment
     with AudioApiClient
     with ConverterService
     with DraftApiClient
+    with FeideApiClient
     with Elastic4sClient
     with HealthController
     with ImageApiClient
@@ -61,6 +62,7 @@ trait TestEnvironment
   val imageApiClient = mock[ImageApiClient]
   val audioApiClient = mock[AudioApiClient]
   val articleApiClient = mock[ArticleApiClient]
+  val feideApiClient = mock[FeideApiClient]
 
   val SearchClients = Map[String, SearchApiClient](
     "articles" -> draftApiClient,

--- a/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
+++ b/src/test/scala/no/ndla/searchapi/controller/SearchControllerTest.scala
@@ -183,4 +183,8 @@ class SearchControllerTest extends UnitSuite with TestEnvironment with ScalatraF
 
   }
 
+  test("That fetching feide user only happens if token is available") {
+    ???
+  }
+
 }

--- a/src/test/scala/no/ndla/searchapi/integration/ArticleApiClientTest.scala
+++ b/src/test/scala/no/ndla/searchapi/integration/ArticleApiClientTest.scala
@@ -13,6 +13,7 @@ import no.ndla.searchapi.model.domain
 import no.ndla.searchapi.model.domain.article.{
   ArticleContent,
   ArticleMetaImage,
+  Availability,
   Copyright,
   LearningResourceType,
   MetaDescription
@@ -39,7 +40,8 @@ class ArticleApiClientTest extends UnitSuite with TestEnvironment {
       new EnumNameSerializer(StepType) +
       new EnumNameSerializer(StepStatus) +
       new EnumNameSerializer(EmbedType) +
-      new EnumNameSerializer(LearningResourceType) ++
+      new EnumNameSerializer(LearningResourceType) +
+      new EnumNameSerializer(Availability) ++
       org.json4s.ext.JodaTimeSerializers.all
 
   override val ndlaClient = new NdlaClient
@@ -77,7 +79,10 @@ class ArticleApiClientTest extends UnitSuite with TestEnvironment {
         "ndalId54321",
         today,
         LearningResourceType.Article,
-        grepCodes = Seq()
+        grepCodes = Seq(),
+        conceptIds = Seq(),
+        availability = Availability.everyone,
+        relatedContent = Seq.empty
       )
 
       val expectedResult = DomainDumpResults[domain.article.Article](

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -92,7 +92,8 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       // To be removed
       embedResources = embedResources,
       // To be removed
-      embedIds = embedIds
+      embedIds = embedIds,
+      availability = "everyone"
     )
     val json = write(original)
     val deserialized = read[SearchableArticle](json)
@@ -183,7 +184,8 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       // To be removed
       embedResources = embedResources,
       // To be removed
-      embedIds = embedIds
+      embedIds = embedIds,
+      availability = "everyone"
     )
 
     val json = write(original)

--- a/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
@@ -47,9 +47,9 @@ class ArticleIndexServiceTest
     articleIndexService.cleanupIndexes()
     articleIndexService.createIndexWithGeneratedName
 
-    articleIndexService.indexDocument(article5, TestData.taxonomyTestBundle, TestData.emptyGrepBundle)
-    articleIndexService.indexDocument(article6, TestData.taxonomyTestBundle, TestData.emptyGrepBundle)
-    articleIndexService.indexDocument(article7, TestData.taxonomyTestBundle, TestData.emptyGrepBundle)
+    articleIndexService.indexDocument(article5, TestData.taxonomyTestBundle, TestData.emptyGrepBundle).get
+    articleIndexService.indexDocument(article6, TestData.taxonomyTestBundle, TestData.emptyGrepBundle).get
+    articleIndexService.indexDocument(article7, TestData.taxonomyTestBundle, TestData.emptyGrepBundle).get
 
     blockUntil(() => { articleIndexService.countDocuments == 3 })
 


### PR DESCRIPTION
Relates to NDLANO/Issues#2609

Filtrerer ut artikler som har `student` eller `teacher` availability basert på rettigheter fra feide accessTokenet som kan sendes med til controlleren for `/group/` og `/` endepunktene i `FeideAuthorization` headeren.

Kan tenkes at det er litt teit å ha feide-auth logikken i selve controlleren nå, men jeg ville holde det utenfor `SearchService` og syns det var litt drastisk med et helt eget service lag for å gjøre en bitteliten request (Om noen er uenig så er jeg åpen for å endre det :smile:).