### PR TITLE
#2732: Send slack error message if any of the attempted indexed documents fail

### DIFF
--- a/src/main/scala/no/ndla/searchapi/model/domain/ReindexResult.scala
+++ b/src/main/scala/no/ndla/searchapi/model/domain/ReindexResult.scala
@@ -7,4 +7,4 @@
 
 package no.ndla.searchapi.model.domain
 
-case class ReindexResult(totalIndexed: Int, millisUsed: Long)
+case class ReindexResult(name: String, failedIndexed: Int, totalIndexed: Int, millisUsed: Long)

--- a/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
+++ b/src/main/scala/no/ndla/searchapi/service/StandaloneIndexing.scala
@@ -116,6 +116,9 @@ object StandaloneIndexing extends LazyLogging {
     }
 
     val errors = reindexResult.collect {
+      case Success(ReindexResult(name, numErrors, totalIndexed, _)) if numErrors > 0 =>
+        val totalDocuments = numErrors + totalIndexed
+        s"Indexing of '$name' finished indexing with $numErrors errors ($totalIndexed/$totalDocuments)"
       case Failure(ex) =>
         logger.error("Indexing failed...", ex)
         ex.getMessage


### PR DESCRIPTION
Fixes NDLANO/Issues#2732

Standalone indekseringen vil nå sende antall feil til slack dersom det
finnes flere enn 0 feilede dokumenter i resultatet fra indekseringen.