### PR TITLE
#2807: Use `data-article-id` when fetching embed ids

### DIFF
--- a/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
+++ b/src/main/scala/no/ndla/searchapi/controller/SearchController.scala
@@ -181,7 +181,10 @@ trait SearchController {
     )
 
     private val embedResource =
-      Param[Option[String]]("embed-resource", "Return only results with embed data-resource the specified resource.")
+      Param[Option[String]](
+        "embed-resource",
+        "Return only results with embed data-resource the specified resource. Can specify multiple with a comma separated list to filter for one of the embed types."
+      )
 
     private val embedId =
       Param[Option[String]](
@@ -250,7 +253,7 @@ trait SearchController {
       val includeMissingResourceTypeGroup =
         booleanOrDefault(this.includeMissingResourceTypeGroup.paramName, default = false)
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
-      val embedResource = paramOrNone(this.embedResource.paramName)
+      val embedResource = paramAsListOfString(this.embedResource.paramName)
       val embedId = paramOrNone(this.embedId.paramName)
 
       getAvailability() match {
@@ -391,7 +394,7 @@ trait SearchController {
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
-      val embedResource = paramOrNone(this.embedResource.paramName)
+      val embedResource = paramAsListOfString(this.embedResource.paramName)
       val embedId = paramOrNone(this.embedId.paramName)
 
       getAvailability().map(
@@ -442,7 +445,7 @@ trait SearchController {
       val grepCodes = paramAsListOfString(this.grepCodes.paramName)
       val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
       val aggregatePaths = paramAsListOfString(this.aggregatePaths.paramName)
-      val embedResource = paramOrNone(this.embedResource.paramName)
+      val embedResource = paramAsListOfString(this.embedResource.paramName)
       val embedId = paramOrNone(this.embedId.paramName)
       val includeOtherStatuses = booleanOrDefault(this.includeOtherStatuses.paramName, default = false)
 

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableArticle.scala
@@ -29,10 +29,6 @@ case class SearchableArticle(
     grepContexts: List[SearchableGrepContext],
     traits: List[String],
     embedAttributes: SearchableLanguageList,
-    // To be removed
-    embedResources: SearchableLanguageList,
-    // To be removed
-    embedIds: SearchableLanguageList,
     embedResourcesAndIds: List[EmbedValues],
     availability: String,
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/SearchableDraft.scala
@@ -33,9 +33,5 @@ case class SearchableDraft(
     grepContexts: List[SearchableGrepContext],
     traits: List[String],
     embedAttributes: SearchableLanguageList,
-    // To be removed
-    embedResources: SearchableLanguageList,
-    // To be removed
-    embedIds: SearchableLanguageList,
     embedResourcesAndIds: List[EmbedValues],
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/MultiDraftSearchSettings.scala
@@ -33,7 +33,7 @@ case class MultiDraftSearchSettings(
     shouldScroll: Boolean,
     searchDecompounded: Boolean,
     aggregatePaths: List[String],
-    embedResource: Option[String],
+    embedResource: List[String],
     embedId: Option[String],
     includeOtherStatuses: Boolean
 )

--- a/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
+++ b/src/main/scala/no/ndla/searchapi/model/search/settings/SearchSettings.scala
@@ -28,7 +28,7 @@ case class SearchSettings(
     shouldScroll: Boolean,
     filterByNoResourceType: Boolean,
     aggregatePaths: List[String],
-    embedResource: Option[String],
+    embedResource: List[String],
     embedId: Option[String],
     availability: List[Availability.Value]
 )

--- a/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -81,11 +81,7 @@ trait ArticleIndexService {
             generateLanguageSupportedFieldList("introduction") ++
             generateLanguageSupportedFieldList("metaDescription") ++
             generateLanguageSupportedFieldList("tags") ++
-            generateLanguageSupportedFieldList("embedAttributes") ++
-            // To be removed
-            generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
-            // To be removed
-            generateLanguageSupportedFieldList("embedIds", keepRaw = true)
+            generateLanguageSupportedFieldList("embedAttributes")
         )
     }
   }

--- a/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -84,11 +84,7 @@ trait DraftIndexService {
             generateLanguageSupportedFieldList("visualElement") ++
             generateLanguageSupportedFieldList("introduction") ++
             generateLanguageSupportedFieldList("tags") ++
-            generateLanguageSupportedFieldList("embedAttributes") ++
-            // To be removed
-            generateLanguageSupportedFieldList("embedResources", keepRaw = true) ++
-            // To be removed
-            generateLanguageSupportedFieldList("embedIds", keepRaw = true)
+            generateLanguageSupportedFieldList("embedAttributes")
         )
     }
   }

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiDraftSearchService.scala
@@ -68,8 +68,8 @@ trait MultiDraftSearchService {
             simpleStringQuery(queryString).field("grepContexts.title", 1),
             idsQuery(queryString)
           ) ++
-            buildNestedEmbedField(Some(queryString), None, settings.language, settings.fallback) ++
-            buildNestedEmbedField(None, Some(queryString), settings.language, settings.fallback)
+            buildNestedEmbedField(List(queryString), None, settings.language, settings.fallback) ++
+            buildNestedEmbedField(List.empty, Some(queryString), settings.language, settings.fallback)
         )
 
       })

--- a/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/MultiSearchService.scala
@@ -65,8 +65,8 @@ trait MultiSearchService {
               simpleStringQuery(q).field("grepContexts.title", 1),
               idsQuery(q)
             ) ++
-              buildNestedEmbedField(Some(q), None, settings.language, settings.fallback) ++
-              buildNestedEmbedField(None, Some(q), settings.language, settings.fallback)
+              buildNestedEmbedField(List(q), None, settings.language, settings.fallback) ++
+              buildNestedEmbedField(List.empty, Some(q), settings.language, settings.fallback)
           ))
       })
 

--- a/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/SearchConverterService.scala
@@ -109,35 +109,6 @@ trait SearchConverterService {
       })
     }
 
-    // To be removed
-    private[service] def getEmbedResources(html: String): List[String] = {
-      parseHtml(html)
-        .select("embed")
-        .asScala
-        .flatMap(getEmbedResources)
-        .toList
-    }
-    // To be removed
-    private def getEmbedResources(embed: Element): List[String] = {
-      val attributesToKeep = List(
-        "data-resource",
-      )
-
-      attributesToKeep.flatMap(attr =>
-        embed.attr(attr) match {
-          case "" => None
-          case a  => Some(a)
-      })
-    }
-    // To be removed
-    private[service] def getEmbedIds(html: String): List[String] = {
-      parseHtml(html)
-        .select("embed")
-        .asScala
-        .flatMap(getEmbedIds)
-        .toList
-    }
-
     private def getEmbedValuesFromEmbed(embed: Element, language: String): EmbedValues = {
       EmbedValues(resource = getEmbedResource(embed), id = getEmbedIds(embed), language = language)
     }
@@ -164,6 +135,7 @@ trait SearchConverterService {
         "data-url",
         "data-resource_id",
         "data-content-id",
+        "data-article-id"
       )
 
       attributesToKeep.flatMap(attr =>
@@ -178,36 +150,6 @@ trait SearchConverterService {
       val contentTuples = content.map(c => c.language -> getAttributes(c.content))
       val visualElementTuples = visualElement.map(v => v.language -> getAttributes(v.resource))
       val attrsGroupedByLanguage = (contentTuples ++ visualElementTuples).groupBy(_._1)
-
-      val languageValues = attrsGroupedByLanguage.map {
-        case (language, values) => LanguageValue(language, values.flatMap(_._2))
-      }
-
-      SearchableLanguageList(languageValues.toSeq)
-    }
-
-    // To be removed
-    private def getEmbedResourcesToIndex(content: Seq[ArticleContent],
-                                         visualElement: Seq[VisualElement]): SearchableLanguageList = {
-      val contentTuples = content.map(c => c.language -> getEmbedResources(c.content))
-      val visualElementTuples = visualElement.map(v => v.language -> getEmbedResources(v.resource))
-      val attrsGroupedByLanguage = (contentTuples ++ visualElementTuples).groupBy(_._1)
-
-      val languageValues = attrsGroupedByLanguage.map {
-        case (language, values) => LanguageValue(language, values.flatMap(_._2))
-      }
-
-      SearchableLanguageList(languageValues.toSeq)
-    }
-
-    // To be removed
-    private def getEmbedIdsToIndex(content: Seq[ArticleContent],
-                                   visualElement: Seq[VisualElement],
-                                   metaImage: Seq[ArticleMetaImage]): SearchableLanguageList = {
-      val contentTuples = content.map(c => c.language -> getEmbedIds(c.content))
-      val visualElementTuples = visualElement.map(v => v.language -> getEmbedIds(v.resource))
-      val metaImageTuples = metaImage.map(m => m.language -> List(m.imageId))
-      val attrsGroupedByLanguage = (contentTuples ++ visualElementTuples ++ metaImageTuples).groupBy(_._1)
 
       val languageValues = attrsGroupedByLanguage.map {
         case (language, values) => LanguageValue(language, values.flatMap(_._2))
@@ -234,11 +176,6 @@ trait SearchConverterService {
       val traits = getArticleTraits(ai.content)
       val embedAttributes = getAttributesToIndex(ai.content, ai.visualElement)
       val embedResourcesAndIds = getEmbedResourcesAndIdsToIndex(ai.content, ai.visualElement, ai.metaImage)
-
-      // To be removed
-      val embedResources = getEmbedResourcesToIndex(ai.content, ai.visualElement)
-      // To be removed
-      val embedIds = getEmbedIdsToIndex(ai.content, ai.visualElement, ai.metaImage)
 
       val articleWithAgreement = converterService.withAgreementCopyright(ai)
 
@@ -279,10 +216,6 @@ trait SearchConverterService {
           traits = traits.toList.distinct,
           embedAttributes = embedAttributes,
           embedResourcesAndIds = embedResourcesAndIds,
-          // To be removed
-          embedResources = embedResources,
-          // To be removed
-          embedIds = embedIds,
           availability = articleWithAgreement.availability.toString
         ))
 
@@ -328,11 +261,6 @@ trait SearchConverterService {
       val traits = getArticleTraits(draft.content)
       val embedAttributes = getAttributesToIndex(draft.content, draft.visualElement)
       val embedResourcesAndIds = getEmbedResourcesAndIdsToIndex(draft.content, draft.visualElement, draft.metaImage)
-
-      // To be removed
-      val embedResources = getEmbedResourcesToIndex(draft.content, draft.visualElement)
-      // To be removed
-      val embedIds = getEmbedIdsToIndex(draft.content, draft.visualElement, draft.metaImage)
 
       val defaultTitle = draft.title
         .sortBy(title => {
@@ -390,10 +318,6 @@ trait SearchConverterService {
           traits = traits.toList.distinct,
           embedAttributes = embedAttributes,
           embedResourcesAndIds = embedResourcesAndIds,
-          // To be removed
-          embedResources = embedResources,
-          // To be removed
-          embedIds = embedIds
         ))
 
     }

--- a/src/test/scala/no/ndla/searchapi/TestData.scala
+++ b/src/test/scala/no/ndla/searchapi/TestData.scala
@@ -1240,7 +1240,7 @@ object TestData {
     shouldScroll = false,
     filterByNoResourceType = false,
     aggregatePaths = List.empty,
-    embedResource = None,
+    embedResource = List.empty,
     embedId = None,
     availability = List.empty
   )
@@ -1267,7 +1267,7 @@ object TestData {
     shouldScroll = false,
     searchDecompounded = false,
     aggregatePaths = List.empty,
-    embedResource = None,
+    embedResource = List.empty,
     embedId = None,
     includeOtherStatuses = false
   )

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableArticleTest.scala
@@ -55,17 +55,6 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
     val embedResourcesAndIds =
       List(EmbedValues(resource = Some("test resource 1"), id = List("test id 1"), language = "nb"))
 
-    // To be removed
-    val embedResources = SearchableLanguageList(
-      Seq(
-        LanguageValue("nb", List("test resource 1", "test resource 2")),
-      ))
-    // To be removed
-    val embedIds = SearchableLanguageList(
-      Seq(
-        LanguageValue("nb", List("test id 1", "test id 2")),
-      ))
-
     val metaImages = List(ArticleMetaImage("1", "alt", "nb"))
 
     val original = SearchableArticle(
@@ -89,10 +78,6 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       traits = List.empty,
       embedAttributes = embedAttrs,
       embedResourcesAndIds = embedResourcesAndIds,
-      // To be removed
-      embedResources = embedResources,
-      // To be removed
-      embedIds = embedIds,
       availability = "everyone"
     )
     val json = write(original)
@@ -174,10 +159,6 @@ class SearchableArticleTest extends UnitSuite with TestEnvironment {
       traits = List.empty,
       embedAttributes = embedAttrs,
       embedResourcesAndIds = embedResourcesAndIds,
-      // To be removed
-      embedResources = embedResources,
-      // To be removed
-      embedIds = embedIds,
       availability = "everyone"
     )
 

--- a/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
+++ b/src/test/scala/no/ndla/searchapi/model/search/SearchableDraftTest.scala
@@ -57,18 +57,6 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
     val embedResourcesAndIds =
       List(EmbedValues(resource = Some("test resource 1"), id = List("test id 1"), language = "nb"))
 
-    // To be removed
-    val embedResources = SearchableLanguageList(
-      Seq(
-        LanguageValue("nb", List("test resource 1", "test resource 2")),
-      ))
-
-    // To be removed
-    val embedIds = SearchableLanguageList(
-      Seq(
-        LanguageValue("nb", List("test id 1", "test id 2")),
-      ))
-
     val original = SearchableDraft(
       id = 100,
       draftStatus = Status(ArticleStatus.DRAFT.toString, Seq(ArticleStatus.PROPOSAL.toString)),
@@ -94,10 +82,6 @@ class SearchableDraftTest extends UnitSuite with TestEnvironment {
       traits = List.empty,
       embedAttributes = embedAttrs,
       embedResourcesAndIds = embedResourcesAndIds,
-      // To be removed
-      embedResources = embedResources,
-      // To be removed
-      embedIds = embedIds
     )
     val json = write(original)
     val deserialized = read[SearchableDraft](json)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -747,7 +747,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
   test("That searches for embedResource does not partial match") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
-        multiDraftSearchSettings.copy(embedResource = Some("conc"), embedId = Some("55")))
+        multiDraftSearchSettings.copy(embedResource = List("conc"), embedId = Some("55")))
     results.totalCount should be(0)
   }
 
@@ -762,7 +762,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
   test("That searches on embedId and embedResource matches when using other parameters") {
     val Success(results) =
       multiDraftSearchService.matchingQuery(
-        multiDraftSearchSettings.copy(query = Some("Ekstra"), embedResource = Some("image"), embedId = Some("55")))
+        multiDraftSearchSettings.copy(query = Some("Ekstra"), embedResource = List("image"), embedId = Some("55")))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)
@@ -772,13 +772,13 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings
-          .copy(query = Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaa"), embedResource = Some("concept"), embedId = Some("77")))
+          .copy(query = Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaa"), embedResource = List("concept"), embedId = Some("77")))
     results.totalCount should be(0)
   }
 
   test("That search on embed data-resource matches") {
     val Success(results) =
-      multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedResource = Some("video")))
+      multiDraftSearchService.matchingQuery(multiDraftSearchSettings.copy(embedResource = List("video")))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)
@@ -930,7 +930,7 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
     val Success(results) =
       multiDraftSearchService.matchingQuery(
         multiDraftSearchSettings
-          .copy(language = Language.AllLanguages, embedResource = Some("concept"), embedId = Some("222")))
+          .copy(language = Language.AllLanguages, embedResource = List("concept"), embedId = Some("222")))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -607,7 +607,7 @@ class MultiSearchServiceTest
 
   test("That searches for embedResource does not partial match") {
     val Success(results) =
-      multiSearchService.matchingQuery(searchSettings.copy(embedResource = Some("vid"), embedId = Some("55")))
+      multiSearchService.matchingQuery(searchSettings.copy(embedResource = List("vid"), embedId = Some("55")))
     results.totalCount should be(0)
   }
 
@@ -622,7 +622,7 @@ class MultiSearchServiceTest
   test("That searches on embedId and embedResource matches when using other parameters") {
     val Success(results) =
       multiSearchService.matchingQuery(
-        searchSettings.copy(query = Some("Ekstra"), embedResource = Some("video"), embedId = Some("77")))
+        searchSettings.copy(query = Some("Ekstra"), embedResource = List("video"), embedId = Some("77")))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)
@@ -632,13 +632,13 @@ class MultiSearchServiceTest
     val Success(results) =
       multiSearchService.matchingQuery(
         searchSettings
-          .copy(query = Some("query-string-without-match"), embedResource = Some("video"), embedId = Some("77")))
+          .copy(query = Some("query-string-without-match"), embedResource = List("video"), embedId = Some("77")))
     results.totalCount should be(0)
   }
 
   test("That search on embed data-resource matches") {
     val Success(results) =
-      multiSearchService.matchingQuery(searchSettings.copy(embedResource = Some("video")))
+      multiSearchService.matchingQuery(searchSettings.copy(embedResource = List("video")))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(12)
@@ -785,7 +785,7 @@ class MultiSearchServiceTest
   test("That searches on embedId and embedResource only returns results with an embed matching both params.") {
     val Success(results) =
       multiSearchService.matchingQuery(
-        searchSettings.copy(language = Language.AllLanguages, embedResource = Some("concept"), embedId = Some("222")))
+        searchSettings.copy(language = Language.AllLanguages, embedResource = List("concept"), embedId = Some("222")))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(11)


### PR DESCRIPTION
Relates to NDLANO/Issues#2807

Trengs for å søke etter `related-article` embeds som bruker `data-article-id` for å spesifisere id'er.
Denne legger også til muligheten for å sende inn flere `embed-resource` som en kommaseparert liste. Dette er nyttig når vi skal finne ut om en artikkel er brukt i andre artikler (Både som `related-article` og som `content-link`).

Kan testes ved å spinne opp lokalt api, reindeksere og sjekke om søk etter embeds fungerer.
Dersom man har test data så skal dette feks returnere id 3 og 28207.

`/search-api/v1/search/editorial/?embed-id=18315&embed-resource=related-content`


Also add functionality to pass multiple embed-resource types with
comma-separated lists.