### PR TITLE
#2847: Allow GREP to fail when indexing single documents

### DIFF
--- a/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/ArticleIndexService.scala
@@ -35,7 +35,7 @@ trait ArticleIndexService {
     override def createIndexRequest(domainModel: Article,
                                     indexName: String,
                                     taxonomyBundle: TaxonomyBundle,
-                                    grepBundle: GrepBundle): Try[IndexRequest] = {
+                                    grepBundle: Option[GrepBundle]): Try[IndexRequest] = {
       searchConverterService.asSearchableArticle(domainModel, taxonomyBundle, grepBundle) match {
         case Success(searchableArticle) =>
           val source = write(searchableArticle)

--- a/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/DraftIndexService.scala
@@ -36,7 +36,7 @@ trait DraftIndexService {
     override def createIndexRequest(domainModel: Draft,
                                     indexName: String,
                                     taxonomyBundle: TaxonomyBundle,
-                                    grepBundle: GrepBundle): Try[IndexRequest] = {
+                                    grepBundle: Option[GrepBundle]): Try[IndexRequest] = {
       searchConverterService.asSearchableDraft(domainModel, taxonomyBundle, grepBundle) match {
         case Success(searchableDraft) =>
           val source = write(searchableDraft)

--- a/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/IndexService.scala
@@ -64,23 +64,30 @@ trait IndexService {
     def createIndexRequest(domainModel: D,
                            indexName: String,
                            taxonomyBundle: TaxonomyBundle,
-                           grepBundle: GrepBundle): Try[IndexRequest]
+                           grepBundle: Option[GrepBundle]): Try[IndexRequest]
 
     def indexDocument(imported: D): Try[D] = {
-      val bundles = for {
-        taxonomyBundle <- taxonomyApiClient.getTaxonomyBundle()
-        grepBundle <- grepApiClient.getGrepBundle()
-      } yield (taxonomyBundle, grepBundle)
-      bundles match {
+      val taxonomyBundleT = taxonomyApiClient.getTaxonomyBundle()
+
+      val grepBundle = grepApiClient.getGrepBundle() match {
+        case Success(bundle) => Some(bundle)
+        case Failure(_) =>
+          logger.error(
+            s"GREP could not be fetched when indexing $documentType ${imported.id.map(id => s"with id: '$id'").getOrElse("")}")
+          None
+      }
+
+      taxonomyBundleT match {
         case Failure(ex) =>
           logger.error(
-            s"Grep and/or Taxonomy could not be fetched when indexing $documentType ${imported.id.map(id => s"with id: '$id'").getOrElse("")}")
+            s"Taxonomy could not be fetched when indexing $documentType ${imported.id.map(id => s"with id: '$id'").getOrElse("")}",
+            ex)
           Failure(ex)
-        case Success((taxonomyBundle, grepBundle)) => indexDocument(imported, taxonomyBundle, grepBundle)
+        case Success(taxonomyBundle) => indexDocument(imported, taxonomyBundle, grepBundle)
       }
     }
 
-    def indexDocument(imported: D, taxonomyBundle: TaxonomyBundle, grepBundle: GrepBundle): Try[D] = {
+    def indexDocument(imported: D, taxonomyBundle: TaxonomyBundle, grepBundle: Option[GrepBundle]): Try[D] = {
       for {
         _ <- getAliasTarget.map {
           case Some(index) => Success(index)
@@ -172,7 +179,7 @@ trait IndexService {
       if (contents.isEmpty) {
         Future.successful { Success(0) }
       } else {
-        val req = contents.map(content => createIndexRequest(content, indexName, taxonomyBundle, grepBundle))
+        val req = contents.map(content => createIndexRequest(content, indexName, taxonomyBundle, Some(grepBundle)))
         val indexRequests = req.collect { case Success(indexRequest) => indexRequest }
         val failedToCreateRequests = req.collect { case Failure(ex)  => Failure(ex) }
 

--- a/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
+++ b/src/main/scala/no/ndla/searchapi/service/search/LearningPathIndexService.scala
@@ -35,7 +35,7 @@ trait LearningPathIndexService {
     override def createIndexRequest(domainModel: LearningPath,
                                     indexName: String,
                                     taxonomyBundle: TaxonomyBundle,
-                                    grepBundle: GrepBundle): Try[IndexRequest] = {
+                                    grepBundle: Option[GrepBundle]): Try[IndexRequest] = {
       searchConverterService.asSearchableLearningPath(domainModel, taxonomyBundle) match {
         case Success(searchableLearningPath) =>
           val source = write(searchableLearningPath)

--- a/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/ArticleIndexServiceTest.scala
@@ -47,9 +47,9 @@ class ArticleIndexServiceTest
     articleIndexService.cleanupIndexes()
     articleIndexService.createIndexWithGeneratedName
 
-    articleIndexService.indexDocument(article5, TestData.taxonomyTestBundle, TestData.emptyGrepBundle).get
-    articleIndexService.indexDocument(article6, TestData.taxonomyTestBundle, TestData.emptyGrepBundle).get
-    articleIndexService.indexDocument(article7, TestData.taxonomyTestBundle, TestData.emptyGrepBundle).get
+    articleIndexService.indexDocument(article5, TestData.taxonomyTestBundle, Some(TestData.emptyGrepBundle)).get
+    articleIndexService.indexDocument(article6, TestData.taxonomyTestBundle, Some(TestData.emptyGrepBundle)).get
+    articleIndexService.indexDocument(article7, TestData.taxonomyTestBundle, Some(TestData.emptyGrepBundle)).get
 
     blockUntil(() => { articleIndexService.countDocuments == 3 })
 
@@ -61,11 +61,11 @@ class ArticleIndexServiceTest
     val articles = sources.map(source => read[SearchableArticle](source))
 
     val Success(expectedArticle5) =
-      searchConverterService.asSearchableArticle(article5, TestData.taxonomyTestBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article5, TestData.taxonomyTestBundle, Some(TestData.emptyGrepBundle))
     val Success(expectedArticle6) =
-      searchConverterService.asSearchableArticle(article6, TestData.taxonomyTestBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article6, TestData.taxonomyTestBundle, Some(TestData.emptyGrepBundle))
     val Success(expectedArticle7) =
-      searchConverterService.asSearchableArticle(article7, TestData.taxonomyTestBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article7, TestData.taxonomyTestBundle, Some(TestData.emptyGrepBundle))
 
     val Some(actualArticle5) = articles.find(p => p.id == article5.id.get)
     val Some(actualArticle6) = articles.find(p => p.id == article6.id.get)

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceAtomicTest.scala
@@ -78,9 +78,9 @@ class MultiDraftSearchServiceAtomicTest
       )
     )
     val draft3 = TestData.draft1.copy(id = Some(3))
-    draftIndexService.indexDocument(draft1, taxonomyTestBundle, grepBundle).get
-    draftIndexService.indexDocument(draft2, taxonomyTestBundle, grepBundle).get
-    draftIndexService.indexDocument(draft3, taxonomyTestBundle, grepBundle).get
+    draftIndexService.indexDocument(draft1, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft2, taxonomyTestBundle, Some(grepBundle)).get
+    draftIndexService.indexDocument(draft3, taxonomyTestBundle, Some(grepBundle)).get
 
     blockUntil(() => draftIndexService.countDocuments == 3)
 

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiDraftSearchServiceTest.scala
@@ -52,10 +52,11 @@ class MultiDraftSearchServiceTest extends IntegrationSuite(EnableElasticsearchCo
       learningPathIndexService.createIndexWithName(SearchApiProperties.SearchIndexes(SearchType.LearningPaths))
 
       val indexedDrafts =
-        draftsToIndex.map(draft => draftIndexService.indexDocument(draft, taxonomyTestBundle, emptyGrepBundle))
+        draftsToIndex.map(draft => draftIndexService.indexDocument(draft, taxonomyTestBundle, Some(emptyGrepBundle)))
 
       val indexedLearningPaths =
-        learningPathsToIndex.map(lp => learningPathIndexService.indexDocument(lp, taxonomyTestBundle, emptyGrepBundle))
+        learningPathsToIndex.map(lp =>
+          learningPathIndexService.indexDocument(lp, taxonomyTestBundle, Some(emptyGrepBundle)))
 
       blockUntil(() => {
         draftIndexService.countDocuments == draftsToIndex.size &&

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceAtomicTest.scala
@@ -77,9 +77,9 @@ class MultiSearchServiceAtomicTest extends IntegrationSuite(EnableElasticsearchC
       )
     )
     val article3 = TestData.article1.copy(id = Some(3))
-    articleIndexService.indexDocument(article1, TestData.taxonomyTestBundle, TestData.grepBundle).get
-    articleIndexService.indexDocument(article2, TestData.taxonomyTestBundle, TestData.grepBundle).get
-    articleIndexService.indexDocument(article3, TestData.taxonomyTestBundle, TestData.grepBundle).get
+    articleIndexService.indexDocument(article1, TestData.taxonomyTestBundle, Some(TestData.grepBundle)).get
+    articleIndexService.indexDocument(article2, TestData.taxonomyTestBundle, Some(TestData.grepBundle)).get
+    articleIndexService.indexDocument(article3, TestData.taxonomyTestBundle, Some(TestData.grepBundle)).get
 
     blockUntil(() => {
       articleIndexService.countDocuments == 3

--- a/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/MultiSearchServiceTest.scala
@@ -56,10 +56,11 @@ class MultiSearchServiceTest
       learningPathIndexService.createIndexWithName(SearchApiProperties.SearchIndexes(SearchType.LearningPaths))
 
       val indexedArticles =
-        articlesToIndex.map(article => articleIndexService.indexDocument(article, taxonomyTestBundle, grepBundle))
+        articlesToIndex.map(article => articleIndexService.indexDocument(article, taxonomyTestBundle, Some(grepBundle)))
 
       val indexedLearningPaths =
-        learningPathsToIndex.map(lp => learningPathIndexService.indexDocument(lp, taxonomyTestBundle, emptyGrepBundle))
+        learningPathsToIndex.map(lp =>
+          learningPathIndexService.indexDocument(lp, taxonomyTestBundle, Some(emptyGrepBundle)))
 
       blockUntil(() => {
         articleIndexService.countDocuments == articlesToIndex.size &&

--- a/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/searchapi/service/search/SearchConverterServiceTest.scala
@@ -26,7 +26,7 @@ import scala.util.{Success, Try}
 class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
 
   override val searchConverterService = new SearchConverterService
-  val sampleArticle = TestData.sampleArticleWithPublicDomain.copy()
+  val sampleArticle: Article = TestData.sampleArticleWithPublicDomain.copy()
 
   val titles = List(
     Title("Bokmål tittel", "nb"),
@@ -75,7 +75,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     TopicResourceConnection("urn:topic:10",
                             "urn:resource:1",
                             "urn:topic-resource:abc123",
-                            true,
+                            primary = true,
                             1,
                             Some("urn:relevance:core")))
   val subject1: TaxSubject = TaxSubject("urn:subject:1", "Subject1", None, Some("/subject:1"), visibleMetadata)
@@ -85,7 +85,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     SubjectTopicConnection("urn:subject:1",
                            "urn:topic:10",
                            "urn:subject-topic:8180abc",
-                           true,
+                           primary = true,
                            1,
                            Some("urn:relevance:core")))
 
@@ -113,28 +113,28 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
   test("That asSearchableArticle converts titles with correct language") {
     val article = TestData.sampleArticleWithByNcSa.copy(title = titles)
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.emptyGrepBundle))
     verifyTitles(searchableArticle)
   }
 
   test("That asSearchable converts articles with correct language") {
     val article = TestData.sampleArticleWithByNcSa.copy(content = articles)
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.emptyGrepBundle))
     verifyArticles(searchableArticle)
   }
 
   test("That asSearchable converts tags with correct language") {
     val article = TestData.sampleArticleWithByNcSa.copy(tags = articleTags)
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.emptyGrepBundle))
     verifyTags(searchableArticle)
   }
 
   test("That asSearchable converts all fields with correct language") {
     val article = TestData.sampleArticleWithByNcSa.copy(title = titles, content = articles, tags = articleTags)
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.emptyGrepBundle))
 
     verifyTitles(searchableArticle)
     verifyArticles(searchableArticle)
@@ -146,7 +146,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     when(converterService.withAgreementCopyright(any[Article]))
       .thenReturn(article.copy(copyright = article.copyright.copy(license = "gnu")))
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.emptyGrepBundle))
     searchableArticle.license should equal("gnu")
   }
 
@@ -154,15 +154,15 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val Success(searchable2) =
       searchConverterService.asSearchableArticle(TestData.article2,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable4) =
       searchConverterService.asSearchableArticle(TestData.article4,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable7) =
       searchConverterService.asSearchableArticle(TestData.article7,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
 
     searchable2.contexts.head.resourceTypes.map(_.id).sorted should be(
       Seq("urn:resourcetype:subjectMaterial", "urn:resourcetype:academicArticle").sorted)
@@ -181,15 +181,15 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val Success(searchable1) =
       searchConverterService.asSearchableArticle(TestData.article1,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable4) =
       searchConverterService.asSearchableArticle(TestData.article4,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable6) =
       searchConverterService.asSearchableArticle(TestData.article6,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
 
     searchable1.contexts.size should be(2)
     searchable1.contexts.head.breadcrumbs.languageValues.map(_.value) should be(
@@ -228,15 +228,15 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val Success(searchable1) =
       searchConverterService.asSearchableArticle(TestData.article1,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable4) =
       searchConverterService.asSearchableArticle(TestData.article4,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable5) =
       searchConverterService.asSearchableArticle(TestData.article5,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
 
     searchable1.contexts.size should be(2)
     searchable1.contexts.map(_.subject.languageValues.map(_.value)) should be(Seq(Seq("Matte"), Seq("Historie")))
@@ -254,15 +254,15 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val Success(searchable1) =
       searchConverterService.asSearchableArticle(TestData.article1,
                                                  taxonomyBundleInvisibleMetadata,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable4) =
       searchConverterService.asSearchableArticle(TestData.article4,
                                                  taxonomyBundleInvisibleMetadata,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable5) =
       searchConverterService.asSearchableArticle(TestData.article5,
                                                  taxonomyBundleInvisibleMetadata,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
 
     searchable1.contexts.size should be(0)
     searchable4.contexts.size should be(0)
@@ -275,15 +275,15 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val Success(searchable1) =
       searchConverterService.asSearchableArticle(TestData.article1,
                                                  taxonomyBundleInvisibleMetadata,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable4) =
       searchConverterService.asSearchableArticle(TestData.article4,
                                                  taxonomyBundleInvisibleMetadata,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable5) =
       searchConverterService.asSearchableArticle(TestData.article5,
                                                  taxonomyBundleInvisibleMetadata,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
 
     searchable1.contexts.size should be(0)
     searchable4.contexts.size should be(0)
@@ -294,15 +294,15 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val Success(searchable1) =
       searchConverterService.asSearchableArticle(TestData.article1,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable4) =
       searchConverterService.asSearchableArticle(TestData.article4,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
     val Success(searchable5) =
       searchConverterService.asSearchableArticle(TestData.article5,
                                                  TestData.taxonomyTestBundle,
-                                                 TestData.emptyGrepBundle)
+                                                 Some(TestData.emptyGrepBundle))
 
     searchable1.contexts.size should be(2)
     searchable4.contexts.size should be(1)
@@ -311,7 +311,9 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("That invisible taxonomy filters are added correctly in drafts") {
     val Success(searchable1) =
-      searchConverterService.asSearchableDraft(TestData.draft1, TestData.taxonomyTestBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableDraft(TestData.draft1,
+                                               TestData.taxonomyTestBundle,
+                                               Some(TestData.emptyGrepBundle))
 
     searchable1.contexts.size should be(3)
   }
@@ -322,7 +324,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
                             SearchableGrepContext("KM123", None),
                             SearchableGrepContext("TT2", None))
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.emptyGrepBundle))
     searchableArticle.grepContexts should equal(grepContexts)
   }
 
@@ -334,7 +336,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       SearchableGrepContext("TT2", Some("Demokrati og medborgerskap"))
     )
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.grepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.grepBundle))
     searchableArticle.grepContexts should equal(grepContexts)
   }
 
@@ -343,7 +345,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val grepContexts = List.empty
 
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.grepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.grepBundle))
     searchableArticle.grepContexts should equal(grepContexts)
   }
 
@@ -353,7 +355,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
                             SearchableGrepContext("KM123", None),
                             SearchableGrepContext("TT2", None))
     val Success(searchableArticle) =
-      searchConverterService.asSearchableDraft(draft, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableDraft(draft, emptyBundle, Some(TestData.emptyGrepBundle))
     searchableArticle.grepContexts should equal(grepContexts)
   }
 
@@ -369,7 +371,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
                             SearchableGrepContext("KM123", Some("tittel123")),
                             SearchableGrepContext("TT2", Some("tittel2")))
     val Success(searchableArticle) =
-      searchConverterService.asSearchableDraft(draft, emptyBundle, grepBundle)
+      searchConverterService.asSearchableDraft(draft, emptyBundle, Some(grepBundle))
     searchableArticle.grepContexts should equal(grepContexts)
   }
 
@@ -384,7 +386,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
     val grepContexts = List.empty
 
     val Success(searchableArticle) =
-      searchConverterService.asSearchableDraft(draft, emptyBundle, grepBundle)
+      searchConverterService.asSearchableDraft(draft, emptyBundle, Some(grepBundle))
     searchableArticle.grepContexts should equal(grepContexts)
   }
 
@@ -399,7 +401,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       )
 
     val Success(searchableArticle) =
-      searchConverterService.asSearchableArticle(article, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article, emptyBundle, Some(TestData.emptyGrepBundle))
     searchableArticle.traits should equal(List("H5P"))
 
     val article2 =
@@ -415,7 +417,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
       )
 
     val Success(searchableArticle2) =
-      searchConverterService.asSearchableArticle(article2, emptyBundle, TestData.emptyGrepBundle)
+      searchConverterService.asSearchableArticle(article2, emptyBundle, Some(TestData.emptyGrepBundle))
     searchableArticle2.traits should equal(List("H5P", "VIDEO"))
   }
 
@@ -427,7 +429,7 @@ class SearchConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That asSearchableDraft extracts all users from notes correctly") {
-    val draft = searchConverterService.asSearchableDraft(TestData.draft5, emptyBundle, TestData.emptyGrepBundle)
+    val draft = searchConverterService.asSearchableDraft(TestData.draft5, emptyBundle, Some(TestData.emptyGrepBundle))
     draft.get.users.length should be(2)
     draft.get.users should be(List("ndalId54321", "ndalId12345"))
   }


### PR DESCRIPTION
Fixes NDLANO/Issues#2847

Denne PR'en tillater GREP å feile ved inkrementell indeksering.
Kan testes ved å spinne opp api'et med `GREP_API_HOST=noesomikkefunker.com` og gjøre en enkel indekseringsrequest å sjekke at indekseringen går igjennom.

Og teste at bulk indeksering fortsatt feiler i samme situasjon (`POST /intern/index`)

---

Eksempel på request for indeksering av enkelt dokuemnt: 

`POST /intern/draft/`
```json
{"id":123,"revision":23,"status":{"current":"QUEUED_FOR_LANGUAGE","other":["IMPORTED"]},"title":[{"title":"En kul tittel","language":"nb"}],"content":[{"content":"<section><p>Noe kult innhold</p></section>","language":"nb"}],"copyright":{"license":"CC-BY-SA-4.0","origin":"","creators":[{"type":"Writer","name":"Jonas"}],"processors":[],"rightsholders":[]},"tags":[{"tags":["årua"],"language":"nb"}],"requiredLibraries":[],"visualElement":[],"introduction":[{"introduction":"Kul intro.","language":"nb"}],"metaDescription":[{"content":"Kul meta","language":"nb"}],"metaImage":[{"imageId":"12048","altText":"Converse-sko. Foto.","language":"nb"},{"imageId":"12048","altText":"Converse sko. Foto.","language":"nn"}],"created":"2017-04-26T12:13:45Z","updated":"2019-05-02T12:52:21Z","updatedBy":"awdadawd","published":"2017-05-03T08:04:14Z","articleType":"standard","notes":[{"note":"Fikset noe greier","user":"awdadw","status":{"current":"PUBLISHED","other":["IMPORTED"]},"timestamp":"2019-02-01T07:12:36Z"}]}
```